### PR TITLE
fix JSON syntax errors and invoke root level properties from their definitions

### DIFF
--- a/xps metadata draft 3.json
+++ b/xps metadata draft 3.json
@@ -1,778 +1,5970 @@
 {
-"$schema": "http://json-schema.org/draft-07/schema#",
-"title": "xps metadata version 0.1",
-"description": "a metadata schema for user uploads of xps data sets"
-"type":"object"
-"definitions":{
-	"Instrument":{
-			"description":"Metadata of the instrument or instrument configuration the dataset was measured using",
-			"type":"object",
-			"properties":{
-				"InstrumentID":{
-					"description":"A unique identifier of the instrument",
-					"$id":"#instrumentid",
-					"type": "integer"
-				},
-				"Instrument manufacturer":{
-					"description":"The name of the company that manufactured the spectrometer",
-					"type":"string",
-					"enum":["SPECS GmbH", "Kratos", "Physical Electronics", "Scienta", "Thermo Fischer Scientific"]
-				}
-				"Intrument model":{
-					"description":"The name of the instrument model",
-					"type":"string",
-				},
-				"Analyzer radius":{
-					"description":"The radius of the hemispherical analyzer in mm",
-					"type":"integer"
-				}
-				"Serial number":{
-							"description":"manufactuerer's unique serial number",
-							"type":"string"
-				},
-				"Year installed":{
-							"description":"the year the instrument was put into operation",
-							"type":"integer"
-				},
-				"Detector type":{
-					"description":"The kind of detector used in the instrument",
-					"type":"string"
-				},
-				"Excitation sources":{
-					"description":"The excitation sources used with this instrument",
-					"type":"array",
-					"items":[{"$ref":"#/definitions/Excitation source"}]
-				}
-				"Additional information":{
-					"description":"Space to enter additional configuration information",
-					"type":"string"
-				}
-			},
-			"required":["InstrumentID","Instrument model"]
-	},
-	"Laboratory":{
-			"description": "The metadata of the laboratory or department where the data was measured",
-			"type": "object",
-			"properties":{
-				"LaboratoryID":{
-					"description":"A unique identifier for the laboratory",
-					"$id":"#laboratoryid",
-					"type":"integer"
-				},
-				"Name":{
-					"description": "The name of the laboratory or depatment",
-					"type":"string"
-				},
-				"Country":{
-					"description":"The country in which the laboratory is located",
-					"type":"string",
-					"enum":["Germany", "Belarus","Canada", "England", "France", "China"]
-				},
-				"City":{
-					"description":"The city in which the laboratory is located",
-					"type":"string",
-					"enum":["Essen","Berlin", "Toronto", "London"]
-				},
-				"Instruments":{
-					"description":"A list of instruments associated with the laboratory",
-					"type":"array",
-					"items":{
-						"$ref":"#instrumentid"
-					},
-					"minItems":0,
-					"uniqueItems":true
-				}
-			},
-			"required":["LaboratoryID", "Name","Country","City"]
-	},
-	"Sample":{
-		"description":"The metadata of the sample from which the dataset was measured",
-		"type":"object",
-		"properties":{
-			"SampleID":{
-				"description": "A unique identifier assigned to the sample",
-				"$id":"#sampleid",
-				"type":"integer"
-			},
-			"Name":{
-				"description":"A user entered name given to the sample",
-				"type":"string",
-				"$ref":"#vamassampleid"
-			},
-			"Composition":{
-				"description":"Keywords to describe which materials are present in the sample",
-				"type":"object",
-				"properties":{
-					"Major components":{"description":"List of the main components in the sample",
-						"type":"array",
-						"items":{
-							"type":"string"
-						},
-						"minItems":1,
-						"uniqueItems":true
-					},
-					"Minor components":{"description":"List of the minor components in the sample",
-						"type":"array",
-						"items":{
-							"type":"string"
-						},
-						"minItems":0,
-						"uniqueItems":true
-					}							
-				}
-			},
-			"Form":{
-				"description":"Keywords describing the physical form of the sample",
-				"type":"array",
-				"items":{
-					"type":"string"
-				},
-				"minItems":1,
-				"uniqueItems":true
-			},
-			"Ex-situ preparation":{
-				"description":"Explanation of steps taken to prepare and mount the sample prior to loading into the measurement instrument",
-				"type":"string"
-			},
-			"In-situ preparation":{
-				"description": "Explanation of steps taken to prepare and mount the sample after loading into the measurement instrument",
-				"type":"string"
-			}
-		},
-		"required":["Name","Composition","Form"]
-	},
-	"Spectrum": {
-		"description": "Metadata describing an individual spectrum in a dataset",
-		"type":"object",
-		"properties":{
-			"Excitation energy":{
-				"description":"The energy of the excitation source that was used to probe the sample in generating the spectrum",
-				"type":"object",
-				"properties":{
-					"Energy":{
-						"description":"The numerical value of the excitation energy used",
-						"type":"number",
-						"$ref":"#vamassourceenergy"
-					},
-					"Units":{
-						"description":"The units used to report the excitation energy",
-						"type":"string",
-						"enum":["eV, keV"],
-						"default":"eV"
-					}
-					}
-				}
-			"SpectrumID": {
-				"description":"A unique identifier assigned to the spectrum",
-				"$id":"#spectrumid",
-				"type":"integer"},
-			"Spectrum type":{
-				"description":"an array of element and emission lines",
-				"type":"array",
-				"items":[					
-					"allOf":[
-						{"$ref":"#vamasspecieslabel"},
-						{"$ref":"#vamastransitionlabel"}
-					]
-				]
-				"enum":[{"$ref":"emissionlines"}],
-				"minItems":1,
-				"uniqueItems":true
-			},
-			"Pass Energy":{
-				"description": "the pass energy used to measure the spectrum. Given in units of eV",
-				"type":"number"
-				"$ref":"#vamasresolution"
-			},
-			"Lens mode":{
-				"description":"The lens mode used to measure the spectrum",
-				"type":"string"
-			},
-			"Dwell time":{
-				"description":"The time spent on each data point in a single scan in milliseconds",
-				"type": "number"
-				"$ref":"#vamasdwelltime"
-			},
-			"Step size": {
-				"description": "The distance between points in the abcissa. In units of eV.",
-				"type":"number"
-				"$ref":"#vamasstep"
-			},
-			"Number of scans averaged":{
-				"description":"The number of scans that has been averaged together",
-				"type":"integer",
-				"$ref":"#vamasnoscans"
-			}
-		},
-		"required":["Excitation energy","Spectrum type","Pass energy"]
-	},
-	"Dataset": {
-		"description":"The metadata describing a dataset",
-		"type":"object",
-		"properties":{
-				"DatasetID":{
-					"description":"A unique identifier of the dataset",
-					"$id":"#datasetid",
-					"type":"integer"},
-				"Date measured":{
-					"description":"The date the dataset was measured",
-					"type":"array"
-					"items":[
-						{"$ref":"#vamasyear"},
-						{"$ref":"#vamasmonth"},
-						{"$ref":"#vamasday"}
-					]
-				},
-				"Spectra":{
-					"description":"A list of the spectra belonging to the dataset",
-					"type":"array",
-					"items":{
-						"description":"A reference to a unique spectrum",
-						"$ref":"#spectrumid"},
-					"minItems":1,
-					"uniqueItems":true}
-				"Conditions": {
-					"description": "A description of the conditions used while the dataset was measured.",
-					"type":"object",
-					"properties":{
-							"Temperature": {
-								"description":"The average temperature of the sample when the dataset was measured",
-								"type":"object",
-								"properties":{
-									"Value":{
-										"description":"The numerical value of the temperature",
-										"type":"number"},
-									"Units":{
-										"description":"The units the temperature is reported in."
-										"type":"string"}
-								}
-							},
-							"Pressure":{
-								"description":"The average pressure of the sample's ambient environment when the dataset was measured",
-								"type":"object",
-								"properties":{
-									"Value":{
-										"description":"The numerical value of the pressure",
-										"type":"number"},
-									"Units":{
-										"description":"The units the pressure is reported in."
-										"type":"string"}}},
-							"Ambient composition":{
-								"description":"The composition of the ambient atmosphere in which the sample was measured",
-								"type":"array",
-								"items":{
-									"description": "A list of all chemicals and their concentrations that were present in the ambient when the sample was measured",
-									"type":"object",
-									"properties":
-										"chemical formula":{
-											"description":"The chemical composition of a component in the ambient environment that the sample was in during measurement of the dataset",
-											"type":"string"},
-										"concentration":{
-											"type":"object",
-											"properties":{
-												"value":{
-													"description":"the numerical value of the component's concentration",
-													"type":"number"},
-												"units":{
-												"description":"The units used in reporting the concentration",
-													"type":"string"}
-												}}
-									}
-								}
-					}
-				}
-				"Link to publication":{
-					"description":"A reference to a persistent identified for the dataset",
-					"type":"URI"
-				},
-				"SpectrometerID":{
-					"description":"A reference to the unique spectrometer used to measure the dataset",
-					"$ref":"#spectrometerid"
-				},
-				"Spectrometer settings":{
-					"description":"The spectrometer settings and configuration that remained constant while measuring the dataset",
-					"type":"object",
-					"properties":{
-						"Analyzer mode":{
-							"description":"The scan mode the analyzer used during measurement of the dataset",
-							"type":"string",
-							"enum":["FAT","FRR", "Snapshot", "Imaging"]},
-						"Analyzer analysis area":{
-							"description":"The size of the area from the sample that was measured",
-							"type":"object",
-							"properties":{
-								"area":{
-									"type":"number"},
-								"units": {
-									"type":"string"}
-								}},
-						"Source strength":{
-							"description":"The strength of the excitation source used during the measurement",
-							"type":"object",
-							"properties":{
-								"strength":{"type":"number"},
-								"units":{"type":"string"}}},
-						"Source beam size":{
-							"description":"The size of the excitation beam on the sample during measurment",
-							"type":"object",
-							"properties":{
-								"x":{
-									"description":"The dimension of the beam in the x direction",
-									"type":"number"},
-								"y":{
-									"description":"The dimension of the beam in the y direction",
-									"type":"number"},
-								"units":{
-									"description":"The units used to report the beam size",
-									"type":"string"}}
-							},
-						"Take-off angle":{
-							"description":"The angle in degree between the sample's surface normal vector and the analyzer's lens axis",
-							"type":"number"},
-						"Analyzer acceptance angle":{
-							"description":"The acceptance angle in degrees of the spectrometer during the measurement of the dataset",
-							"type":"number"}	
-						"Entrance slit":{
-							"descritpion":"The size of the entrance aperture to the analyzer in units of mm",
-							"type":"string"},					
-					}
-				},
-				"UserID":{
-					"description":"A unique reference to the user who uploaded the data",
-					"$ref":"#userid"
-				},
-				"SampleID":{
-					"description":"A reference to the sample from which the dataset was measured",
-					"$ref": "#sampleid"
-				}					
-		},
-		"required":["DatasetID", "SampleID", "UserID","Date measured", "Spectra", "SpectrometerID"]
-	},
-	"Calibration": {
-		"Instrument calibration":{
-				"description":"Information on the calibration procedure used to calibrate the instrument",
-				"type":"object",
-				"properties":{
-					"Protocol":{
-						"description":"The protocol used for calibrating the spectrometer",
-						"type":"string",
-						"enum":["ISO 15472:2010", "ISO 15472:2001"]
-					},
-					"Values":{
-						"description":"The binding energy values obtained from the calibrated spectrometer of the standard elements",
-						"type":"array",
-						"items":{
-							"type":"object",
-							"properties":{
-								"Emission line":{
-									"description":"The emission line used for calibration",
-									"type":"string",
-									"enum":["Au4f7/2", "Cu2p3/2", "Ag3d5/2", "Fermi"]
-								},
-								"Binding energy":{
-									"description":"The calibrated binding energy value of the specified emission line in units of eV",
-									"type":"number"
-								}
-							}
-						},
-						"minItems":1,
-						"uniqueItems":true
-					},
-					"Calibration date":{
-							"description":"The date the calibration was performed",
-							"type":"date"
-					},
-					"DatasetID":{
-						"description":"A link to the dataset",
-						"$ref":"#datasetid"
-					}
-				}
-		},
-		"Binding energy reference":{
-				"description":"binding energy scale adjustment, used in cases where samples are not conductive",
-				"type":"object",
-				"properties":{
-					"Emission line":{
-						"type":"string",
-						"enum":["C1s", "O1s", "Au4f7/2"]
-					},
-					"Binding energy":{
-						"description":"The binding energy that the specified emission line appeard at, after adjusting the binding energy scale, in units of eV",
-						"type":"number"}
-				}
-		}
-	},
-	"User":{
-		"description":"Metadata of a registered user in the system",
-		"type":"object",
-		"properties":{
-			"UserID":{
-				"description":"A unique identifier of the user",
-				"$id":"#userid"
-				"type":"integer"
-			},
-			"Given name":{
-				"description":"The given name of the user",
-				"type":"string"
-			},
-			"Family name":{
-				"description":"The family name of the user",
-				"type":"string"
-			},
-			"Email":{
-				"description":"Email addresses of the user",
-				"type":"array",
-				"items":{
-					"description":"email addresses",
-					"type":"string"
-				},
-				"minItems":1,
-				"uniqueItems":true
-			}
-			"Laboratories":{
-				"description":"A list of laboratories that the user is affiliated with",
-				"type":"array",
-				"items":{
-					"$ref":"#laboratoryid"
-				},
-				"minItems":0,
-				"uniqueItems":true
-			},
-			"Instruments":{
-				"description":"A list of spectrometers associated with the user",
-				"type":"array",
-				"items":{
-					"$ref":"#instrumentid"
-				},
-				"minItems":0,
-				"uniqueItems":true
-			},
-			"Uploaded datasets":{
-				"description":"A list of datasets uploaded by the user",
-				"type":"array",
-				"items":{
-					"$ref":"#datasetid"
-				},
-				"minItems":0,
-				"uniqueItems":true
-			},
-			"Favorite datasets":{
-				"description":"A list of datasets that the user has marked as favorite",
-				"type":"array",
-				"items":{
-					"$ref":"#datasetid"
-				},
-				"minItems":0,
-				"uniqueItems":true
-			},
-		}
-	},
-	"VAMAS":{
-		"description":"Metadata contained in the VAMAS file format",
-		"type":"object",
-		"properties":{
-			"header":{
-				"description":"VAMAS file header",
-				"type":"object",
-				"properties":{
-					"formatID":{
-						"description":"A description of the data format standard used",
-						"type":"string"
-					},
-					"instituteID":{
-						"description":"The name of the institute from which the data came",
-						"type":"string"
-					},
-					"instrumentModelID":{},
-					"operatorID":{},
-					"experimentID":{},
-					"noCommentLines":{},
-					"commentLines":{},
-					"expMode":{
-						"description":"A keyword that denotes what kind of experiment was performed in the dataset. If the keyword is MAP, then each spectrum was measured from a point on a 2D spatial array. If SDP each spectrum refers to a specific layer in a depth profile. If MAPDP, each spectrum refers to a spectrum in a map and at a specific depth in a depth profile. If NORM, each spectrum may be independant from the others.",
-						"type":"string",
-						"ennum":["MAP","SDP","MAPDP","NORM","MAPSV","SDPSV","SEM","MAPSVDP"]
-						"default":"NORM"
-					},
-					"scanMode":{
-						"description":"A keyword that specifies whether the abscissa values have a constant spacing, an irregular spacing, or whether the data is a map",
-						"type":"string",
-						"enum":["REGULAR", "IRREGULAR", "MAPPING"]
-					},
-					"expVarLabel":{},
-					"expVarUnit":{},
-					"noBlocks":{}
-				}
-			},
-			"block":{
-				"description":"A collection of spectral data and metadata",
-				"type":"object",
-				"properties":{
-					"blockID":{
-						"description":"The name of the data block",
-						"type":"string",
-						"$id":"#vamasblockid"
-					},
-					"sampleID":{
-						"description":"The name of the sample",
-						"type":"string",
-						"$id":"#vamassampleid"
-					},
-					"year":{
-						"$id":"#vamasyear"
-					},
-					"month":{
-						"$id":"#vamasmonth"
-					},
-					"day":{
-						"$id":"#vamasday"
-					},
-					"hour":{},
-					"minute":{},
-					"second":{},
-					"noHrsInAdvanceOfGMT":{},
-					"noCommentLines":{},
-					"technique":{
-						"description":"A keyword that specifies the technique used to measure the data",
-						"type":"string",
-						"enum":["XPS", "AES diff", "AES dir", "EDX", "ELS","FABMS", "ISS", "SIMS","SNMS","UPS","XRF"]
-					},
-					"expVarValue":{},
-					"sourceLabel":{},
-					"sourceEnergy":{
-						"description":"The energy of the excitation source in eV",
-						"type":"number",
-						"$id":"#vamassourceenergy"
-					},
-					"sourceAnalyzerAngle":{
-						"description":"The angle between the excitation source and the analyzer lens axis",
-						"type":"number",
-						"$id":"#vamassourceanalyzerangle"
-					},
-					"analyzerMode":{
-						"description":"Measurement mode of the analyzer",
-						"type":"string",
-						"enum":["FAT","FRR"],
-						"$id":"#vamasanalyzermode"
-					},
-					"resolution":{
-						"description":"The resolution of the instrument during spectrum measurement. For XPS it corresponds to pass energy"
-						"type":"number"
-						"$id":"#vamasresolution"
-					},
-					"magnification":{},
-					"workfunction":{},
-					"targetBias":{},
-					"analyzerWidthX":{},
-					"analyzerWidthY":{},
-					"analyzerTakeOffPolarAngle":{},
-					"analyzerAzimuth":{},
-					"speciesLabel":{
-						"description":"A label to identify the element of the specrtrum",
-						"type":"string"
-						"$id":"#vamasspecieslabel"
-					},
-					"transitionLabel":{
-						"description":"A label that specifies the transition, a.k.a. emission line",
-						"type":"string",
-						"$id":"#vamastransitionlabel"
-					},
-					"particleCharge":{},
-					"abscissaLabel":{
-						"description":"The variable name for the abscissa data",
-						"type":"string",
-						"enum":["kinetic energy", "binding energy"],
-						"$id":"#vamasabscissalabel"
-					},
-					"abscissaUnits":{
-						"description":"The units used for the abscicca data",
-						"type":"string",
-						"$ref":"#units"
-						"$id":"#vamasabscissaunits"
-					},
-					"abscissaStart":{},
-					"abscissaStep":{
-						"description":"Step size of the abscissa",
-						"type":"number",
-						"$id":"#vamasstep"
-					},
-					"noVariables":{},
-					"variableLabel1":{
-						"description":"The label of the ordinate data",
-						"type":"string"
-						"$id":"#vamasvar1label"
-					},
-					"variableUnits1":{
-						"description":"The units used for the first experimental variable",
-						"type":"string",
-						"$ref":"#units"
-					},
-					"variableLabel2":{},
-					"variableUnits2":{
-						"description":"The units used for the second experimental variable",
-						"type":"string",
-						"$ref":"#units"
-					},
-					"signalMode":{
-						"description":"The signal counting mode used to measure the data",
-						"type":"string",
-						"enum":["analogue", "pulse counting"]
-					},
-					"dwellTime":{
-						"description":"The integration time used for each abscicca value",
-						"type":"number",
-						"$id":"#vamasdwelltime"
-					},
-					"noScans":{
-						"description":"The number of scans used to make the spectrum",
-						"type":"integer"
-						"$id":"#vamasnoscans"
-					},
-					"timeCorrection":{},
-					"sampleAngleTilt":{},
-					"sampleTiltAzimuth":{},
-					"sampleRotation":{},
-					"noAdditionalParameters":{},
-					"paramLabel1":{},
-					"paramUnit1":{},
-					"paramValue1":{},
-					"paramLabel2":{},
-					"paramUnit2":{},
-					"paramValue2":{},
-					"numOrdValues":{},
-					"minOrdValue1":{},
-					"maxOrdValue1":{},
-					"minOrdValue2":{},
-					"maxOrdValue2":{},
-					"dataString":{
-						"description":"The numerical data of the spectrum",
-						"type":"array",
-						"items":{
-							"type":"number"}
-					}
-				}			
-			}		
-		}
-	},
-	"Units":{
-		"description":"The physical units used for measured properties. The abreviations have the following meanings. 'c/s': counts per second, 'd': dimensionless, 'degree': angle in degrees, 'eV': electronvolts, 'K': Kelvin, 'micro C':microcoulombs, 'micro m': micrometers, 'm/s':meters per second, 'n': not defined, 'nA': nanoamps, 'ps': picoseconds, 's':seconds, 'u': unified atomic mass units, 'V':volts",
-		"type":"string",
-		"enum":["eV","u","s","c/s","d","degree","K","micro C", "micro m", "m/s", "n","nA", "ps","u", "V"]
-		"$id":"#units"
-	}
-	"Emission lines":{
-		"description":"All the allowed values for emission line labels",
-		"type":"array",
-		"$id":"#emissionlines",
-		"items":[
-			"enum":[
-				["Ac", "4d"], ["Ac", "4d3/2"], ["Ac", "4d5/2"], ["Ac", "4f"], ["Ac", "4f5/2"], ["Ac", "4f7/2"], ["Ac", "4p"], ["Ac", "4p1/2"], ["Ac", "4p3/2"], ["Ac", "5d"], ["Ac", "5d3/2"], ["Ac", "5d5/2"], ["Ac", "5p"], ["Ac", "5p1/2"], ["Ac", "5p3/2"], ["Ac", "5s"], ["Ag", "3d"], ["Ag", "3d3/2"], ["Ag", "3d5/2"], ["Ag", "3p"], ["Ag", "3p1/2"], ["Ag", "3p3/2"], ["Ag", "3s"], ["Ag", "4d"], ["Ag", "4d3/2"], ["Ag", "4d5/2"], ["Ag", "4p"], ["Ag", "4p1/2"], ["Ag", "4p3/2"], ["Ag", "4s"], ["Ag", "MNN"], ["Al", "2p"], ["Al", "2p1/2"], ["Al", "2p3/2"], ["Al", "2s"], ["Al", "3s"], ["Al", "KLL"], ["Al", "LMM"], ["Ar", "2p"], ["Ar", "2p1/2"], ["Ar", "2p3/2"], ["Ar", "2s"], ["Ar", "3p"], ["Ar", "3p1/2"], ["Ar", "3p3/2"], ["Ar", "3s"], ["Ar", "LMM"], ["As", "3d"], ["As", "3d3/2"], ["As", "3d5/2"], ["As", "3p"], ["As", "3p1/2"], ["As", "3p3/2"], ["As", "3s"], ["As", "4p"], ["As", "4p1/2"], ["As", "4p3/2"], ["As", "LMM"], ["At", "4d"], ["At", "4d3/2"], ["At", "4d5/2"], ["At", "4f"], ["At", "4f5/2"], ["At", "4f7/2"], ["At", "4p"], ["At", "4p1/2"], ["At", "4p3/2"], ["At", "4s"], ["At", "5d"], ["At", "5d3/2"], ["At", "5d5/2"], ["At", "5p"], ["At", "5p1/2"], ["At", "5p3/2"], ["At", "5s"], ["At", "6p"], ["At", "6p1/2"], ["At", "6p3/2"], ["At", "6s"], ["Au", "4d"], ["Au", "4d3/2"], ["Au", "4d5/2"], ["Au", "4f"], ["Au", "4f5/2"], ["Au", "4f7/2"], ["Au", "4p"], ["Au", "4p1/2"], ["Au", "4p3/2"], ["Au", "4s"], ["Au", "5d"], ["Au", "5d3/2"], ["Au", "5d5/2"], ["Au", "5p"], ["Au", "5p1/2"], ["Au", "5p3/2"], ["Au", "5s"], ["Au", "MNN"], ["Au", "NOO"], ["B", "1s"], ["B", "2p"], ["B", "2p1/2"], ["B", "2p3/2"], ["B", "KLL"], ["Ba", "3d"], ["Ba", "3d3/2"], ["Ba", "3d5/2"], ["Ba", "3p"], ["Ba", "3p1/2"], ["Ba", "3p3/2"], ["Ba", "4d"], ["Ba", "4d3/2"], ["Ba", "4d5/2"], ["Ba", "4p"], ["Ba", "4p1/2"], ["Ba", "4p3/2"], ["Ba", "4s"], ["Ba", "5p"], ["Ba", "5p1/2"], ["Ba", "5p3/2"], ["Ba", "5s"], ["Ba", "MNN"], ["Be", "1s"], ["Be", "KLL"], ["Bi", "4d"], ["Bi", "4d3/2"], ["Bi", "4d5/2"], ["Bi", "4f"], ["Bi", "4f5/2"], ["Bi", "4f7/2"], ["Bi", "4p"], ["Bi", "4p1/2"], ["Bi", "4p3/2"], ["Bi", "4s"], ["Bi", "5d"], ["Bi", "5d3/2"], ["Bi", "5d5/2"], ["Bi", "5p"], ["Bi", "5p1/2"], ["Bi", "5p3/2"], ["Bi", "5s"], ["Bi", "6p"], ["Bi", "6p1/2"], ["Bi", "6p3/2"], ["Bi", "6s"], ["Br", "3d"], ["Br", "3d3/2"], ["Br", "3d5/2"], ["Br", "3p"], ["Br", "3p1/2"], ["Br", "3p3/2"], ["Br", "3s"], ["Br", "4p"], ["Br", "4p1/2"], ["Br", "4p3/2"], ["Br", "4s"], ["Br", "LMM"], ["Br", "MNN"], ["C", "1s"], ["C", "2p"], ["C", "2p1/2"], ["C", "2p3/2"], ["C", "KLL"], ["Ca", "2p"], ["Ca", "2p1/2"], ["Ca", "2p3/2"], ["Ca", "2s"], ["Ca", "3p"], ["Ca", "3p1/2"], ["Ca", "3p3/2"], ["Ca", "3s"], ["Ca", "LMM"], ["Cd", "3d"], ["Cd", "3d3/2"], ["Cd", "3d5/2"], ["Cd", "3p"], ["Cd", "3p1/2"], ["Cd", "3p3/2"], ["Cd", "3s"], ["Cd", "4d"], ["Cd", "4d3/2"], ["Cd", "4d5/2"], ["Cd", "4p"], ["Cd", "4p1/2"], ["Cd", "4p3/2"], ["Cd", "4s"], ["Cd", "MNN"], ["Ce", "3d"], ["Ce", "3d3/2"], ["Ce", "3d5/2"], ["Ce", "3p"], ["Ce", "3p3/2"], ["Ce", "4d"], ["Ce", "4d3/2"], ["Ce", "4d5/2"], ["Ce", "4f"], ["Ce", "4f5/2"], ["Ce", "4f7/2"], ["Ce", "4p"], ["Ce", "4p1/2"], ["Ce", "4p3/2"], ["Ce", "4s"], ["Ce", "5p"], ["Ce", "5p1/2"], ["Ce", "5p3/2"], ["Ce", "5s"], ["Ce", "LMM"], ["Cl", "2p"], ["Cl", "2p1/2"], ["Cl", "2p3/2"], ["Cl", "2s"], ["Cl", "3p"], ["Cl", "3p1/2"], ["Cl", "3p3/2"], ["Cl", "3s"], ["Cl", "LMM"], ["Co", "2p"], ["Co", "2p1/2"], ["Co", "2p3/2"], ["Co", "2s"], ["Co", "3d"], ["Co", "3d3/2"], ["Co", "3d5/2"], ["Co", "3p"], ["Co", "3p1/2"], ["Co", "3p3/2"], ["Co", "3s"], ["Co", "LMM"], ["Cr", "2p"], ["Cr", "2p1/2"], ["Cr", "2p3/2"], ["Cr", "2s"], ["Cr", "3d"], ["Cr", "3d3/2"], ["Cr", "3d5/2"], ["Cr", "3p"], ["Cr", "3p1/2"], ["Cr", "3p3/2"], ["Cr", "3s"], ["Cr", "LMM"], ["Cs", "3d"], ["Cs", "3d3/2"], ["Cs", "3d5/2"], ["Cs", "3p"], ["Cs", "3p1/2"], ["Cs", "3p3/2"], ["Cs", "3s"], ["Cs", "4d"], ["Cs", "4d3/2"], ["Cs", "4d5/2"], ["Cs", "4p"], ["Cs", "4p1/2"], ["Cs", "4p3/2"], ["Cs", "4s"], ["Cs", "5p"], ["Cs", "5p1/2"], ["Cs", "5p3/2"], ["Cs", "5s"], ["Cs", "MNN"], ["Cu", "2p"], ["Cu", "2p1/2"], ["Cu", "2p3/2"], ["Cu", "2s"], ["Cu", "3d"], ["Cu", "3d3/2"], ["Cu", "3d5/2"], ["Cu", "3p"], ["Cu", "3p1/2"], ["Cu", "3p3/2"], ["Cu", "3s"], ["Cu", "LMM"], ["Dy", "4d"], ["Dy", "4d3/2"], ["Dy", "4d5/2"], ["Dy", "4f"], ["Dy", "4f5/2"], ["Dy", "4f7/2"], ["Dy", "4p"], ["Dy", "4p1/2"], ["Dy", "4p3/2"], ["Dy", "4s"], ["Dy", "5p"], ["Dy", "5p1/2"], ["Dy", "5p3/2"], ["Dy", "5s"], ["Dy", "MVV"], ["Er", "4d"], ["Er", "4d3/2"], ["Er", "4d5/2"], ["Er", "4f"], ["Er", "4f5/2"], ["Er", "4f7/2"], ["Er", "4p"], ["Er", "4p1/2"], ["Er", "4p3/2"], ["Er", "4s"], ["Er", "5p"], ["Er", "5p1/2"], ["Er", "5p3/2"], ["Er", "5s"], ["Er", "MVV"], ["Eu", "3d"], ["Eu", "3d3/2"], ["Eu", "3d5/2"], ["Eu", "4d"], ["Eu", "4d3/2"], ["Eu", "4d5/2"], ["Eu", "4p"], ["Eu", "4p1/2"], ["Eu", "4p3/2"], ["Eu", "4s"], ["Eu", "5p"], ["Eu", "5p1/2"], ["Eu", "5p3/2"], ["Eu", "5s"], ["Eu", "MNN"], ["F", "1s"], ["F", "2p"], ["F", "2p1/2"], ["F", "2p3/2"], ["F", "2s"], ["F", "KLL"], ["Fe", "2p"], ["Fe", "2p1/2"], ["Fe", "2p3/2"], ["Fe", "2s"], ["Fe", "3d"], ["Fe", "3d3/2"], ["Fe", "3d5/2"], ["Fe", "3p"], ["Fe", "3p1/2"], ["Fe", "3p3/2"], ["Fe", "3s"], ["Fe", "LMM"], ["Fr", "4d"], ["Fr", "4d3/2"], ["Fr", "4d5/2"], ["Fr", "4f"], ["Fr", "4f5/2"], ["Fr", "4f7/2"], ["Fr", "4p"], ["Fr", "4p1/2"], ["Fr", "4p3/2"], ["Fr", "4s"], ["Fr", "5d"], ["Fr", "5d3/2"], ["Fr", "5d5/2"], ["Fr", "5p"], ["Fr", "5p1/2"], ["Fr", "5p3/2"], ["Fr", "5s"], ["Fr", "6p"], ["Fr", "6p1/2"], ["Fr", "6p3/2"], ["Fr", "6s"], ["Ga", "2p"], ["Ga", "2p1/2"], ["Ga", "2p3/2"], ["Ga", "2s"], ["Ga", "3d"], ["Ga", "3d3/2"], ["Ga", "3d5/2"], ["Ga", "3p"], ["Ga", "3p1/2"], ["Ga", "3p3/2"], ["Ga", "3s"], ["Ga", "4p"], ["Ga", "4p1/2"], ["Ga", "4p3/2"], ["Ga", "LMM"], ["Gd", "3d"], ["Gd", "3d3/2"], ["Gd", "3d5/2"], ["Gd", "4d"], ["Gd", "4d3/2"], ["Gd", "4d5/2"], ["Gd", "4p"], ["Gd", "4p1/2"], ["Gd", "4p3/2"], ["Gd", "4s"], ["Gd", "5p"], ["Gd", "5p1/2"], ["Gd", "5p3/2"], ["Gd", "5s"], ["Gd", "MNN"], ["Ge", "2p"], ["Ge", "2p1/2"], ["Ge", "2p3/2"], ["Ge", "3d"], ["Ge", "3d3/2"], ["Ge", "3d5/2"], ["Ge", "3p"], ["Ge", "3p1/2"], ["Ge", "3p3/2"], ["Ge", "3s"], ["Ge", "4p"], ["Ge", "4p1/2"], ["Ge", "4p3/2"], ["Ge", "LMM"], ["H", "1s"], ["He", "1s"], ["Hf", "4d"], ["Hf", "4d3/2"], ["Hf", "4d5/2"], ["Hf", "4f"], ["Hf", "4f5/2"], ["Hf", "4f7/2"], ["Hf", "4p"], ["Hf", "4p1/2"], ["Hf", "4p3/2"], ["Hf", "4s"], ["Hf", "5d"], ["Hf", "5d3/2"], ["Hf", "5d5/2"], ["Hf", "5p"], ["Hf", "5p1/2"], ["Hf", "5p3/2"], ["Hf", "5s"], ["Hf", "MVV"], ["Hg", "4d"], ["Hg", "4d3/2"], ["Hg", "4d5/2"], ["Hg", "4f"], ["Hg", "4f5/2"], ["Hg", "4f7/2"], ["Hg", "4p"], ["Hg", "4p1/2"], ["Hg", "4p3/2"], ["Hg", "4s"], ["Hg", "5d"], ["Hg", "5d3/2"], ["Hg", "5d5/2"], ["Hg", "5p"], ["Hg", "5p1/2"], ["Hg", "5p3/2"], ["Hg", "5s"], ["Hg", "MNN"], ["Ho", "4d"], ["Ho", "4d3/2"], ["Ho", "4d5/2"], ["Ho", "4f"], ["Ho", "4f5/2"], ["Ho", "4f7/2"], ["Ho", "4p"], ["Ho", "4p1/2"], ["Ho", "4p3/2"], ["Ho", "4s"], ["Ho", "5p"], ["Ho", "5p1/2"], ["Ho", "5p3/2"], ["Ho", "5s"], ["Ho", "MVV"], ["I", "3d"], ["I", "3d3/2"], ["I", "3d5/2"], ["I", "3p"], ["I", "3p1/2"], ["I", "3p3/2"], ["I", "3s"], ["I", "4d"], ["I", "4d3/2"], ["I", "4d5/2"], ["I", "4p"], ["I", "4p1/2"], ["I", "4p3/2"], ["I", "4s"], ["I", "5p"], ["I", "5p1/2"], ["I", "5p3/2"], ["I", "5s"], ["I", "MNN"], ["In", "3d"], ["In", "3d3/2"], ["In", "3d5/2"], ["In", "3p"], ["In", "3p1/2"], ["In", "3p3/2"], ["In", "3s"], ["In", "4d"], ["In", "4d3/2"], ["In", "4d5/2"], ["In", "4p"], ["In", "4p1/2"], ["In", "4p3/2"], ["In", "4s"], ["In", "5p"], ["In", "5p1/2"], ["In", "5p3/2"], ["In", "MNN"], ["Ir", "4d"], ["Ir", "4d3/2"], ["Ir", "4d5/2"], ["Ir", "4f"], ["Ir", "4f5/2"], ["Ir", "4f7/2"], ["Ir", "4p"], ["Ir", "4p1/2"], ["Ir", "4p3/2"], ["Ir", "4s"], ["Ir", "5d"], ["Ir", "5d3/2"], ["Ir", "5d5/2"], ["Ir", "5p"], ["Ir", "5p1/2"], ["Ir", "5p3/2"], ["Ir", "5s"], ["K", "2p"], ["K", "2p1/2"], ["K", "2p3/2"], ["K", "2s"], ["K", "3p"], ["K", "3p1/2"], ["K", "3p3/2"], ["K", "3s"], ["K", "LMM"], ["Kr", "3d"], ["Kr", "3d3/2"], ["Kr", "3d5/2"], ["Kr", "3p"], ["Kr", "3p1/2"], ["Kr", "3p3/2"], ["Kr", "3s"], ["Kr", "4p"], ["Kr", "4p1/2"], ["Kr", "4p3/2"], ["Kr", "4s"], ["La", "3d"], ["La", "3d3/2"], ["La", "3d5/2"], ["La", "3p"], ["La", "3p1/2"], ["La", "3p3/2"], ["La", "4d"], ["La", "4d3/2"], ["La", "4d5/2"], ["La", "4p"], ["La", "4p1/2"], ["La", "4p3/2"], ["La", "4s"], ["La", "5p"], ["La", "5p1/2"], ["La", "5p3/2"], ["La", "5s"], ["La", "MNN"], ["Li", "1s"], ["Lu", "4d"], ["Lu", "4d3/2"], ["Lu", "4d5/2"], ["Lu", "4f"], ["Lu", "4f5/2"], ["Lu", "4f7/2"], ["Lu", "4p"], ["Lu", "4p1/2"], ["Lu", "4p3/2"], ["Lu", "4s"], ["Lu", "5d"], ["Lu", "5d3/2"], ["Lu", "5d5/2"], ["Lu", "5p"], ["Lu", "5p1/2"], ["Lu", "5p3/2"], ["Lu", "5s"], ["Lu", "MVV"], ["Mg", "1s"], ["Mg", "2p"], ["Mg", "2p1/2"], ["Mg", "2p3/2"], ["Mg", "2s"], ["Mg", "3s"], ["Mg", "KLL"], ["Mn", "2p"], ["Mn", "2p1/2"], ["Mn", "2p3/2"], ["Mn", "2s"], ["Mn", "3d"], ["Mn", "3d3/2"], ["Mn", "3d5/2"], ["Mn", "3p"], ["Mn", "3p1/2"], ["Mn", "3p3/2"], ["Mn", "3s"], ["Mn", "LMM"], ["Mo", "3d"], ["Mo", "3d3/2"], ["Mo", "3d5/2"], ["Mo", "3p"], ["Mo", "3p1/2"], ["Mo", "3p3/2"], ["Mo", "3s"], ["Mo", "4d"], ["Mo", "4d3/2"], ["Mo", "4d5/2"], ["Mo", "4p"], ["Mo", "4p1/2"], ["Mo", "4p3/2"], ["Mo", "4s"], ["Mo", "MNV"], ["N", "1s"], ["N", "2p"], ["N", "2p1/2"], ["N", "2p3/2"], ["N", "KLL"], ["Na", "1s"], ["Na", "2p"], ["Na", "2p1/2"], ["Na", "2p3/2"], ["Na", "2s"], ["Na", "3s"], ["Na", "KLL"], ["Nb", "3d"], ["Nb", "3d3/2"], ["Nb", "3d5/2"], ["Nb", "3p"], ["Nb", "3p1/2"], ["Nb", "3p3/2"], ["Nb", "3s"], ["Nb", "4d"], ["Nb", "4d3/2"], ["Nb", "4d5/2"], ["Nb", "4p"], ["Nb", "4p1/2"], ["Nb", "4p3/2"], ["Nb", "4s"], ["Nb", "MNV"], ["Nd", "3d"], ["Nd", "3d3/2"], ["Nd", "3d5/2"], ["Nd", "4d"], ["Nd", "4d3/2"], ["Nd", "4d5/2"], ["Nd", "4f"], ["Nd", "4f5/2"], ["Nd", "4f7/2"], ["Nd", "4p"], ["Nd", "4p1/2"], ["Nd", "4p3/2"], ["Nd", "4s"], ["Nd", "5p"], ["Nd", "5p1/2"], ["Nd", "5p3/2"], ["Nd", "5s"], ["Nd", "MNN"], ["Ne", "1s"], ["Ne", "2p"], ["Ne", "2p1/2"], ["Ne", "2p3/2"], ["Ne", "2s"], ["Ni", "2p"], ["Ni", "2p1/2"], ["Ni", "2p3/2"], ["Ni", "2s"], ["Ni", "3d"], ["Ni", "3d3/2"], ["Ni", "3d5/2"], ["Ni", "3p"], ["Ni", "3p1/2"], ["Ni", "3p3/2"], ["Ni", "3s"], ["Ni", "LMM"], ["O", "1s"], ["O", "2p"], ["O", "2p1/2"], ["O", "2p3/2"], ["O", "2s"], ["O", "KLL"], ["Os", "4d"], ["Os", "4d3/2"], ["Os", "4d5/2"], ["Os", "4f"], ["Os", "4f5/2"], ["Os", "4f7/2"], ["Os", "4p"], ["Os", "4p1/2"], ["Os", "4p3/2"], ["Os", "4s"], ["Os", "5p"], ["Os", "5p1/2"], ["Os", "5p3/2"], ["Os", "5s"], ["Os", "NOO"], ["P", "2p"], ["P", "2p1/2"], ["P", "2p3/2"], ["P", "2s"], ["P", "3p"], ["P", "3p1/2"], ["P", "3p3/2"], ["P", "3s"], ["P", "KLL"], ["P", "LMM"], ["Pb", "4d"], ["Pb", "4d3/2"], ["Pb", "4d5/2"], ["Pb", "4f"], ["Pb", "4f5/2"], ["Pb", "4f7/2"], ["Pb", "4p"], ["Pb", "4p1/2"], ["Pb", "4p3/2"], ["Pb", "4s"], ["Pb", "5d"], ["Pb", "5d3/2"], ["Pb", "5d5/2"], ["Pb", "5p"], ["Pb", "5p1/2"], ["Pb", "5p3/2"], ["Pb", "5s"], ["Pb", "6p"], ["Pb", "6p1/2"], ["Pb", "6p3/2"], ["Pb", "6s"], ["Pd", "3d"], ["Pd", "3d3/2"], ["Pd", "3d5/2"], ["Pd", "3p"], ["Pd", "3p1/2"], ["Pd", "3p3/2"], ["Pd", "3s"], ["Pd", "4d"], ["Pd", "4d3/2"], ["Pd", "4d5/2"], ["Pd", "4p"], ["Pd", "4p1/2"], ["Pd", "4p3/2"], ["Pd", "4s"], ["Pd", "MNN"], ["Pm", "3d"], ["Pm", "3d3/2"], ["Pm", "3d5/2"], ["Pm", "4d"], ["Pm", "4d3/2"], ["Pm", "4d5/2"], ["Pm", "4f"], ["Pm", "4f5/2"], ["Pm", "4f7/2"], ["Pm", "4p"], ["Pm", "4p1/2"], ["Pm", "4p3/2"], ["Pm", "4s"], ["Pm", "5p"], ["Pm", "5p1/2"], ["Pm", "5p3/2"], ["Pm", "5s"], ["Po", "4d"], ["Po", "4d3/2"], ["Po", "4d5/2"], ["Po", "4f"], ["Po", "4f5/2"], ["Po", "4f7/2"], ["Po", "4p"], ["Po", "4p1/2"], ["Po", "4p3/2"], ["Po", "4s"], ["Po", "5d"], ["Po", "5d3/2"], ["Po", "5d5/2"], ["Po", "5p"], ["Po", "5p1/2"], ["Po", "5p3/2"], ["Po", "5s"], ["Po", "6p"], ["Po", "6p1/2"], ["Po", "6p3/2"], ["Po", "6s"], ["Pr", "3d"], ["Pr", "3d3/2"], ["Pr", "3d5/2"], ["Pr", "3p"], ["Pr", "3p3/2"], ["Pr", "4d"], ["Pr", "4d3/2"], ["Pr", "4d5/2"], ["Pr", "4f"], ["Pr", "4f5/2"], ["Pr", "4f7/2"], ["Pr", "4p"], ["Pr", "4p1/2"], ["Pr", "4p3/2"], ["Pr", "4s"], ["Pr", "5p"], ["Pr", "5p1/2"], ["Pr", "5p3/2"], ["Pr", "5s"], ["Pr", "MNN"], ["Pt", "4d"], ["Pt", "4d3/2"], ["Pt", "4d5/2"], ["Pt", "4f"], ["Pt", "4f5/2"], ["Pt", "4f7/2"], ["Pt", "4p"], ["Pt", "4p1/2"], ["Pt", "4p3/2"], ["Pt", "4s"], ["Pt", "5d"], ["Pt", "5d3/2"], ["Pt", "5d5/2"], ["Pt", "5p"], ["Pt", "5p1/2"], ["Pt", "5p3/2"], ["Pt", "5s"], ["Pt", "MNN"], ["Ra", "4d"], ["Ra", "4d3/2"], ["Ra", "4d5/2"], ["Ra", "4f"], ["Ra", "4f5/2"], ["Ra", "4f7/2"], ["Ra", "4p"], ["Ra", "4p1/2"], ["Ra", "4p3/2"], ["Ra", "4s"], ["Ra", "5d"], ["Ra", "5d3/2"], ["Ra", "5d5/2"], ["Ra", "5p"], ["Ra", "5p1/2"], ["Ra", "5p3/2"], ["Ra", "5s"], ["Ra", "6p"], ["Ra", "6p1/2"], ["Ra", "6p3/2"], ["Ra", "6s"], ["Rb", "3d"], ["Rb", "3d3/2"], ["Rb", "3d5/2"], ["Rb", "3p"], ["Rb", "3p1/2"], ["Rb", "3p3/2"], ["Rb", "3s"], ["Rb", "4p"], ["Rb", "4p1/2"], ["Rb", "4p3/2"], ["Rb", "4s"], ["Rb", "LMM"], ["Re", "4d"], ["Re", "4d3/2"], ["Re", "4d5/2"], ["Re", "4f"], ["Re", "4f5/2"], ["Re", "4f7/2"], ["Re", "4p"], ["Re", "4p1/2"], ["Re", "4p3/2"], ["Re", "4s"], ["Re", "5d"], ["Re", "5d3/2"], ["Re", "5d5/2"], ["Re", "5p"], ["Re", "5p1/2"], ["Re", "5p3/2"], ["Re", "5s"], ["Re", "MVV"], ["Rh", "3d"], ["Rh", "3d3/2"], ["Rh", "3d5/2"], ["Rh", "3p"], ["Rh", "3p1/2"], ["Rh", "3p3/2"], ["Rh", "3s"], ["Rh", "4d"], ["Rh", "4d3/2"], ["Rh", "4d5/2"], ["Rh", "4p"], ["Rh", "4p1/2"], ["Rh", "4p3/2"], ["Rh", "4s"], ["Rh", "MNV"], ["Rn", "4d"], ["Rn", "4d3/2"], ["Rn", "4d5/2"], ["Rn", "4f"], ["Rn", "4f5/2"], ["Rn", "4f7/2"], ["Rn", "4p"], ["Rn", "4p1/2"], ["Rn", "4p3/2"], ["Rn", "4s"], ["Rn", "5d"], ["Rn", "5d3/2"], ["Rn", "5d5/2"], ["Rn", "5p"], ["Rn", "5p1/2"], ["Rn", "5p3/2"], ["Rn", "5s"], ["Rn", "6p"], ["Rn", "6p1/2"], ["Rn", "6p3/2"], ["Rn", "6s"], ["Ru", "3d"], ["Ru", "3d3/2"], ["Ru", "3d5/2"], ["Ru", "3p"], ["Ru", "3p1/2"], ["Ru", "3p3/2"], ["Ru", "3s"], ["Ru", "4d"], ["Ru", "4d3/2"], ["Ru", "4d5/2"], ["Ru", "4p"], ["Ru", "4p1/2"], ["Ru", "4p3/2"], ["Ru", "4s"], ["Ru", "MNN"], ["S", "2p"], ["S", "2p1/2"], ["S", "2p3/2"], ["S", "2s"], ["S", "3p"], ["S", "3p1/2"], ["S", "3p3/2"], ["S", "3s"], ["S", "LMM"], ["Sb", "3d"], ["Sb", "3d3/2"], ["Sb", "3d5/2"], ["Sb", "3p"], ["Sb", "3p1/2"], ["Sb", "3p3/2"], ["Sb", "3s"], ["Sb", "4d"], ["Sb", "4d3/2"], ["Sb", "4d5/2"], ["Sb", "4p"], ["Sb", "4p1/2"], ["Sb", "4p3/2"], ["Sb", "4s"], ["Sb", "5p"], ["Sb", "5p1/2"], ["Sb", "5p3/2"], ["Sb", "5s"], ["Sb", "MNN"], ["Sc", "2p"], ["Sc", "2p1/2"], ["Sc", "2p3/2"], ["Sc", "2s"], ["Sc", "3d"], ["Sc", "3d3/2"], ["Sc", "3d5/2"], ["Sc", "3p"], ["Sc", "3p1/2"], ["Sc", "3p3/2"], ["Sc", "3s"], ["Sc", "LMM"], ["Se", "3d"], ["Se", "3d3/2"], ["Se", "3d5/2"], ["Se", "3p"], ["Se", "3p1/2"], ["Se", "3p3/2"], ["Se", "3s"], ["Se", "4p"], ["Se", "4p1/2"], ["Se", "4p3/2"], ["Se", "LMM"], ["Si", "2p"], ["Si", "2p1/2"], ["Si", "2p3/2"], ["Si", "2s"], ["Si", "3p"], ["Si", "3p1/2"], ["Si", "3p3/2"], ["Si", "3s"], ["Si", "KLL"], ["Si", "LMM"], ["Sm", "3d"], ["Sm", "3d3/2"], ["Sm", "3d5/2"], ["Sm", "4d"], ["Sm", "4d3/2"], ["Sm", "4d5/2"], ["Sm", "4f"], ["Sm", "4f5/2"], ["Sm", "4f7/2"], ["Sm", "4p"], ["Sm", "4p1/2"], ["Sm", "4p3/2"], ["Sm", "4s"], ["Sm", "5p"], ["Sm", "5p1/2"], ["Sm", "5p3/2"], ["Sm", "5s"], ["Sm", "MNN"], ["Sn", "3d"], ["Sn", "3d3/2"], ["Sn", "3d5/2"], ["Sn", "3p"], ["Sn", "3p1/2"], ["Sn", "3p3/2"], ["Sn", "3s"], ["Sn", "4d"], ["Sn", "4d3/2"], ["Sn", "4d5/2"], ["Sn", "4p"], ["Sn", "4p1/2"], ["Sn", "4p3/2"], ["Sn", "4s"], ["Sn", "5p"], ["Sn", "5p1/2"], ["Sn", "5p3/2"], ["Sn", "5s"], ["Sn", "MNN"], ["Sr", "3d"], ["Sr", "3d3/2"], ["Sr", "3d5/2"], ["Sr", "3p"], ["Sr", "3p1/2"], ["Sr", "3p3/2"], ["Sr", "3s"], ["Sr", "4p"], ["Sr", "4p1/2"], ["Sr", "4p3/2"], ["Sr", "4s"], ["Sr", "LMM"], ["Ta", "4d"], ["Ta", "4d3/2"], ["Ta", "4d5/2"], ["Ta", "4f"], ["Ta", "4f5/2"], ["Ta", "4f7/2"], ["Ta", "4p"], ["Ta", "4p1/2"], ["Ta", "4p3/2"], ["Ta", "4s"], ["Ta", "5d"], ["Ta", "5d3/2"], ["Ta", "5d5/2"], ["Ta", "5p"], ["Ta", "5p1/2"], ["Ta", "5p3/2"], ["Ta", "5s"], ["Ta", "MVV"], ["Tb", "3d"], ["Tb", "3d3/2"], ["Tb", "3d5/2"], ["Tb", "4d"], ["Tb", "4d3/2"], ["Tb", "4d5/2"], ["Tb", "4f"], ["Tb", "4f5/2"], ["Tb", "4f7/2"], ["Tb", "4p"], ["Tb", "4p1/2"], ["Tb", "4p3/2"], ["Tb", "4s"], ["Tb", "5p"], ["Tb", "5p1/2"], ["Tb", "5p3/2"], ["Tb", "5s"], ["Tb", "MNN"], ["Tc", "3d"], ["Tc", "3d3/2"], ["Tc", "3d5/2"], ["Tc", "3p"], ["Tc", "3p1/2"], ["Tc", "3p3/2"], ["Tc", "3s"], ["Tc", "4d"], ["Tc", "4d3/2"], ["Tc", "4d5/2"], ["Tc", "4p"], ["Tc", "4p1/2"], ["Tc", "4p3/2"], ["Tc", "4s"], ["Te", "3d"], ["Te", "3d3/2"], ["Te", "3d5/2"], ["Te", "3p"], ["Te", "3p1/2"], ["Te", "3p3/2"], ["Te", "3s"], ["Te", "4d"], ["Te", "4d3/2"], ["Te", "4d5/2"], ["Te", "4p"], ["Te", "4p1/2"], ["Te", "4p3/2"], ["Te", "4s"], ["Te", "5p"], ["Te", "5p1/2"], ["Te", "5p3/2"], ["Te", "5s"], ["Te", "MNN"], ["Th", "4d"], ["Th", "4d3/2"], ["Th", "4d5/2"], ["Th", "4f"], ["Th", "4f5/2"], ["Th", "4f7/2"], ["Th", "4p"], ["Th", "4p1/2"], ["Th", "4p3/2"], ["Th", "5d"], ["Th", "5d3/2"], ["Th", "5d5/2"], ["Th", "5p"], ["Th", "5p1/2"], ["Th", "5p3/2"], ["Th", "5s"], ["Th", "6p"], ["Th", "6p1/2"], ["Th", "6p3/2"], ["Th", "6s"], ["Ti", "2p"], ["Ti", "2p1/2"], ["Ti", "2p3/2"], ["Ti", "2s"], ["Ti", "3d"], ["Ti", "3d3/2"], ["Ti", "3d5/2"], ["Ti", "3p"], ["Ti", "3p1/2"], ["Ti", "3p3/2"], ["Ti", "3s"], ["Ti", "LMM"], ["Tl", "4d"], ["Tl", "4d3/2"], ["Tl", "4d5/2"], ["Tl", "4f"], ["Tl", "4f5/2"], ["Tl", "4f7/2"], ["Tl", "4p"], ["Tl", "4p1/2"], ["Tl", "4p3/2"], ["Tl", "4s"], ["Tl", "5d"], ["Tl", "5d3/2"], ["Tl", "5d5/2"], ["Tl", "5p"], ["Tl", "5p1/2"], ["Tl", "5p3/2"], ["Tl", "5s"], ["Tl", "NOO"], ["Tm", "4d"], ["Tm", "4d3/2"], ["Tm", "4d5/2"], ["Tm", "4f"], ["Tm", "4f5/2"], ["Tm", "4f7/2"], ["Tm", "4p"], ["Tm", "4p1/2"], ["Tm", "4p3/2"], ["Tm", "4s"], ["Tm", "5p"], ["Tm", "5p1/2"], ["Tm", "5p3/2"], ["Tm", "5s"], ["Tm", "MVV"], ["U", "4d"], ["U", "4d3/2"], ["U", "4d5/2"], ["U", "4f"], ["U", "4f5/2"], ["U", "4f7/2"], ["U", "4s"], ["U", "5d"], ["U", "5d3/2"], ["U", "5d5/2"], ["U", "6p"], ["U", "6p1/2"], ["U", "6p3/2"], ["V", "2p"], ["V", "2p1/2"], ["V", "2p3/2"], ["V", "2s"], ["V", "3d"], ["V", "3d3/2"], ["V", "3d5/2"], ["V", "3p"], ["V", "3p1/2"], ["V", "3p3/2"], ["V", "3s"], ["V", "LMM"], ["W", "4d"], ["W", "4d3/2"], ["W", "4d5/2"], ["W", "4f"], ["W", "4f5/2"], ["W", "4f7/2"], ["W", "4p"], ["W", "4p1/2"], ["W", "4p3/2"], ["W", "4s"], ["W", "5d"], ["W", "5d3/2"], ["W", "5d5/2"], ["W", "5p"], ["W", "5p1/2"], ["W", "5p3/2"], ["W", "5s"], ["W", "MVV"], ["Xe", "3d"], ["Xe", "3d3/2"], ["Xe", "3d5/2"], ["Xe", "3p"], ["Xe", "3p1/2"], ["Xe", "3p3/2"], ["Xe", "3s"], ["Xe", "4d"], ["Xe", "4d3/2"], ["Xe", "4d5/2"], ["Xe", "4p"], ["Xe", "4p1/2"], ["Xe", "4p3/2"], ["Xe", "4s"], ["Xe", "5p"], ["Xe", "5p1/2"], ["Xe", "5p3/2"], ["Xe", "5s"], ["Xe", "MNN"], ["Y", "3d"], ["Y", "3d3/2"], ["Y", "3d5/2"], ["Y", "3p"], ["Y", "3p1/2"], ["Y", "3p3/2"], ["Y", "3s"], ["Y", "4d"], ["Y", "4d3/2"], ["Y", "4d5/2"], ["Y", "4p"], ["Y", "4p1/2"], ["Y", "4p3/2"], ["Y", "4s"], ["Y", "LMM"], ["Yb", "4d"], ["Yb", "4d3/2"], ["Yb", "4d5/2"], ["Yb", "4f"], ["Yb", "4f5/2"], ["Yb", "4f7/2"], ["Yb", "4p"], ["Yb", "4p1/2"], ["Yb", "4p3/2"], ["Yb", "4s"], ["Yb", "5p"], ["Yb", "5p1/2"], ["Yb", "5p3/2"], ["Yb", "5s"], ["Yb", "MVV"], ["Zn", "2p"], ["Zn", "2p1/2"], ["Zn", "2p3/2"], ["Zn", "2s"], ["Zn", "3d"], ["Zn", "3d3/2"], ["Zn", "3d5/2"], ["Zn", "3p"], ["Zn", "3p1/2"], ["Zn", "3p3/2"], ["Zn", "3s"], ["Zn", "LMM"], ["Zr", "3d"], ["Zr", "3d3/2"], ["Zr", "3d5/2"], ["Zr", "3p"], ["Zr", "3p1/2"], ["Zr", "3p3/2"], ["Zr", "3s"], ["Zr", "4d"], ["Zr", "4d3/2"], ["Zr", "4d5/2"], ["Zr", "4p"], ["Zr", "4p1/2"], ["Zr", "4p3/2"], ["Zr", "4s"], ["Zr", "LMM"], ["Zr", "MNN"], ["survey", ""], ["valence", ""]
-			]
-		],
-		"maxItems":1		
-	}
-	"Excitation source":{
-		"description":"A photon source used for photoemission",
-		"type":"object",
-		"properties":{
-			"Source to analyzer angle":{
-				"description":"The angle between the excitation source and the analyzer's lens axis",
-				"type":"number"
-				}
-			"Source":{
-				"type":"object"
-				"oneOf":[
-					{"$ref": "#/definitions/Synchrotron"},
-					{"$ref": "#/definitions/Anode"},
-					{"$ref": "#/definitions/Gas discharge"},
-					{"$ref": "#/definitions/Laser"}
-					]
-				}
-			}
-		}
-
-	"Synchrotron":{
-		"type":"object",
-		"properties":{
-			"Synchrotron name":{
-				"description":"The name of the synchrotron",
-				"type":"string"
-				},
-			"Beamline":{
-				"type":"object",
-				"properties":{
-					"Name":{
-						"description":"The name of the beamline",
-						"type":"string"
-						},
-					"Energy range":{
-						"description":"The photon energy range of the beamline, in eV".
-						"type":"string"
-						},
-					"Source kind":{
-						"type":"string",
-						"enum":["Bending magnet", "Wiggler", "Undulator"]
-						},
-					"Monochromator kind":{
-						"type":"string"
-						},
-					"Polarization":{
-						"type":"string"
-						},
-					"Spot size range":{
-						"description":"The minimum and maximum spot size in micrometers"
-						"type":"string"
-						}
-					}
-				}
-			}
-		},
-	"Anode":{
-		"type":"object",
-		"properties":{
-			"Anode material":{
-				"description":"The material used as the anode to generate X-rays by electron bombardment",
-				"type":"string",
-				"enum":["Al","Mg","Ag","Cr","Ga"]
-				},
-			"Spot size":{
-				"description":"Range of spot size diameters for the radiation at the surface of the sample, in units of micrometers",
-				"type":"string"
-				},
-			"Monochromated":{
-				"type":"boolean"
-				},
-			"Max voltage":{
-				"description":"The maximum voltage allowed, in units of kV",
-				"type":"number"
-				},
-			"Max power":{
-				"description":"The maximum power allowed, in units of kW",
-				"type":"number"
-				}
-			}
-		},
-	"Gas discharge":{
-		"type":"object",
-		"properties":{
-			"Gas type":{
-				"description":"The gas used in the discharge lamp",
-				"type":"string",
-				"enum":["He","Ar"]
-				},
-			"Monochromated":{
-				"type":"boolean"
-				}
-			}
-		},
-	"Laser":{
-		"type":"object",
-		"properties":{
-			"Energy range":{
-				"description":"The energy range possible, in units of eV",
-				"type":"string"
-				}
-			}
-		}	
-	}
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "title": "xps metadata version 0.1",
+    "description": "a metadata schema for user uploads of xps data sets",
+    "type": "object",
+    "definitions": {
+        "Instrument": {
+            "description": "Metadata of the instrument or instrument configuration the dataset was measured using",
+            "type": "object",
+            "properties": {
+                "InstrumentID": {
+                    "description": "A unique identifier of the instrument",
+                    "$id": "#instrumentid",
+                    "type": "integer"
+                },
+                "Instrument manufacturer": {
+                    "description": "The name of the company that manufactured the spectrometer",
+                    "type": "string",
+                    "enum": [
+                        "SPECS GmbH",
+                        "Kratos",
+                        "Physical Electronics",
+                        "Scienta",
+                        "Thermo Fischer Scientific"
+                    ]
+                },
+                "Intrument model": {
+                    "description": "The name of the instrument model",
+                    "type": "string"
+                },
+                "Analyzer radius": {
+                    "description": "The radius of the hemispherical analyzer in mm",
+                    "type": "integer"
+                },
+                "Serial number": {
+                    "description": "manufactuerer's unique serial number",
+                    "type": "string"
+                },
+                "Year installed": {
+                    "description": "the year the instrument was put into operation",
+                    "type": "integer"
+                },
+                "Detector type": {
+                    "description": "The kind of detector used in the instrument",
+                    "type": "string"
+                },
+                "Excitation sources": {
+                    "description": "The excitation sources used with this instrument",
+                    "type": "array",
+                    "items": [{"$ref": "#/definitions/Excitation source"}]
+                },
+                "Additional information": {
+                    "description": "Space to enter additional configuration information",
+                    "type": "string"
+                }
+            },
+            "required": [
+                "InstrumentID",
+                "Instrument model"
+            ]
+        },
+        "Laboratory": {
+            "description": "The metadata of the laboratory or department where the data was measured",
+            "type": "object",
+            "properties": {
+                "LaboratoryID": {
+                    "description": "A unique identifier for the laboratory",
+                    "$id": "#laboratoryid",
+                    "type": "integer"
+                },
+                "Name": {
+                    "description": "The name of the laboratory or depatment",
+                    "type": "string"
+                },
+                "Country": {
+                    "description": "The country in which the laboratory is located",
+                    "type": "string",
+                    "enum": [
+                        "Germany",
+                        "Belarus",
+                        "Canada",
+                        "England",
+                        "France",
+                        "China"
+                    ]
+                },
+                "City": {
+                    "description": "The city in which the laboratory is located",
+                    "type": "string",
+                    "enum": [
+                        "Essen",
+                        "Berlin",
+                        "Toronto",
+                        "London"
+                    ]
+                },
+                "Instruments": {
+                    "description": "A list of instruments associated with the laboratory",
+                    "type": "array",
+                    "items": {"$ref": "#instrumentid"},
+                    "minItems": 0,
+                    "uniqueItems": true
+                }
+            },
+            "required": [
+                "LaboratoryID",
+                "Name",
+                "Country",
+                "City"
+            ]
+        },
+        "Sample": {
+            "description": "The metadata of the sample from which the dataset was measured",
+            "type": "object",
+            "properties": {
+                "SampleID": {
+                    "description": "A unique identifier assigned to the sample",
+                    "$id": "#sampleid",
+                    "type": "integer"
+                },
+                "Name": {
+                    "description": "A user entered name given to the sample",
+                    "type": "string",
+                    "$ref": "#vamassampleid"
+                },
+                "Composition": {
+                    "description": "Keywords to describe which materials are present in the sample",
+                    "type": "object",
+                    "properties": {
+                        "Major components": {
+                            "description": "List of the main components in the sample",
+                            "type": "array",
+                            "items": {"type": "string"},
+                            "minItems": 1,
+                            "uniqueItems": true
+                        },
+                        "Minor components": {
+                            "description": "List of the minor components in the sample",
+                            "type": "array",
+                            "items": {"type": "string"},
+                            "minItems": 0,
+                            "uniqueItems": true
+                        }
+                    }
+                },
+                "Form": {
+                    "description": "Keywords describing the physical form of the sample",
+                    "type": "array",
+                    "items": {"type": "string"},
+                    "minItems": 1,
+                    "uniqueItems": true
+                },
+                "Ex-situ preparation": {
+                    "description": "Explanation of steps taken to prepare and mount the sample prior to loading into the measurement instrument",
+                    "type": "string"
+                },
+                "In-situ preparation": {
+                    "description": "Explanation of steps taken to prepare and mount the sample after loading into the measurement instrument",
+                    "type": "string"
+                }
+            },
+            "required": [
+                "Name",
+                "Composition",
+                "Form"
+            ]
+        },
+        "Spectrum": {
+            "description": "Metadata describing an individual spectrum in a dataset",
+            "type": "object",
+            "properties": {
+                "Excitation energy": {
+                    "description": "The energy of the excitation source that was used to probe the sample in generating the spectrum",
+                    "type": "object",
+                    "properties": {
+                        "Energy": {
+                            "description": "The numerical value of the excitation energy used",
+                            "type": "number",
+                            "$ref": "#vamassourceenergy"
+                        },
+                        "Units": {
+                            "description": "The units used to report the excitation energy",
+                            "type": "string",
+                            "enum": ["eV, keV"],
+                            "default": "eV"
+                        }
+                    }
+                },
+                "SpectrumID": {
+                    "description": "A unique identifier assigned to the spectrum",
+                    "$id": "#spectrumid",
+                    "type": "integer"
+                },
+                "Spectrum type": {
+                    "description": "an array of element and emission lines",
+                    "type": "array",
+                    "items": {"allOf": [
+                        {"$ref": "#vamasspecieslabel"},
+                        {"$ref": "#vamastransitionlabel"}
+                    ]},
+                    "enum": [{"$ref": "emissionlines"}],
+                    "minItems": 1,
+                    "uniqueItems": true
+                },
+                "Pass Energy": {
+                    "description": "the pass energy used to measure the spectrum. Given in units of eV",
+                    "type": "number",
+                    "$ref": "#vamasresolution"
+                },
+                "Lens mode": {
+                    "description": "The lens mode used to measure the spectrum",
+                    "type": "string"
+                },
+                "Dwell time": {
+                    "description": "The time spent on each data point in a single scan in milliseconds",
+                    "type": "number",
+                    "$ref": "#vamasdwelltime"
+                },
+                "Step size": {
+                    "description": "The distance between points in the abcissa. In units of eV.",
+                    "type": "number",
+                    "$ref": "#vamasstep"
+                },
+                "Number of scans averaged": {
+                    "description": "The number of scans that has been averaged together",
+                    "type": "integer",
+                    "$ref": "#vamasnoscans"
+                }
+            },
+            "required": [
+                "Excitation energy",
+                "Spectrum type",
+                "Pass energy"
+            ]
+        },
+        "Dataset": {
+            "description": "The metadata describing a dataset",
+            "type": "object",
+            "properties": {
+                "DatasetID": {
+                    "description": "A unique identifier of the dataset",
+                    "$id": "#datasetid",
+                    "type": "integer"
+                },
+                "Date measured": {
+                    "description": "The date the dataset was measured",
+                    "type": "array",
+                    "items": [
+                        {"$ref": "#vamasyear"},
+                        {"$ref": "#vamasmonth"},
+                        {"$ref": "#vamasday"}
+                    ]
+                },
+                "Spectra": {
+                    "description": "A list of the spectra belonging to the dataset",
+                    "type": "array",
+                    "items": {
+                        "description": "A reference to a unique spectrum",
+                        "$ref": "#spectrumid"
+                    },
+                    "minItems": 1,
+                    "uniqueItems": true
+                },
+                "Conditions": {
+                    "description": "A description of the conditions used while the dataset was measured.",
+                    "type": "object",
+                    "properties": {
+                        "Temperature": {
+                            "description": "The average temperature of the sample when the dataset was measured",
+                            "type": "object",
+                            "properties": {
+                                "Value": {
+                                    "description": "The numerical value of the temperature",
+                                    "type": "number"
+                                },
+                                "Units": {
+                                    "description": "The units the temperature is reported in.",
+                                    "type": "string"
+                                }
+                            }
+                        },
+                        "Pressure": {
+                            "description": "The average pressure of the sample's ambient environment when the dataset was measured",
+                            "type": "object",
+                            "properties": {
+                                "Value": {
+                                    "description": "The numerical value of the pressure",
+                                    "type": "number"
+                                },
+                                "Units": {
+                                    "description": "The units the pressure is reported in.",
+                                    "type": "string"
+                                }
+                            }
+                        },
+                        "Ambient composition": {
+                            "description": "The composition of the ambient atmosphere in which the sample was measured",
+                            "type": "array",
+                            "items": {
+                                "description": "A list of all chemicals and their concentrations that were present in the ambient when the sample was measured",
+                                "type": "object",
+                                "properties": {
+                                    "chemical formula": {
+                                        "description": "The chemical composition of a component in the ambient environment that the sample was in during measurement of the dataset",
+                                        "type": "string"
+                                    },
+                                    "concentration": {
+                                        "type": "object",
+                                        "properties": {
+                                            "value": {
+                                                "description": "the numerical value of the component's concentration",
+                                                "type": "number"
+                                            },
+                                            "units": {
+                                                "description": "The units used in reporting the concentration",
+                                                "type": "string"
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "Link to publication": {
+                        "description": "A reference to a persistent identified for the dataset",
+                        "type": "URI"
+                    },
+                    "SpectrometerID": {
+                        "description": "A reference to the unique spectrometer used to measure the dataset",
+                        "$ref": "#spectrometerid"
+                    },
+                    "Spectrometer settings": {
+                        "description": "The spectrometer settings and configuration that remained constant while measuring the dataset",
+                        "type": "object",
+                        "properties": {
+                            "Analyzer mode": {
+                                "description": "The scan mode the analyzer used during measurement of the dataset",
+                                "type": "string",
+                                "enum": [
+                                    "FAT",
+                                    "FRR",
+                                    "Snapshot",
+                                    "Imaging"
+                                ]
+                            },
+                            "Analyzer analysis area": {
+                                "description": "The size of the area from the sample that was measured",
+                                "type": "object",
+                                "properties": {
+                                    "area": {"type": "number"},
+                                    "units": {"type": "string"}
+                                }
+                            },
+                            "Source strength": {
+                                "description": "The strength of the excitation source used during the measurement",
+                                "type": "object",
+                                "properties": {
+                                    "strength": {"type": "number"},
+                                    "units": {"type": "string"}
+                                }
+                            },
+                            "Source beam size": {
+                                "description": "The size of the excitation beam on the sample during measurment",
+                                "type": "object",
+                                "properties": {
+                                    "x": {
+                                        "description": "The dimension of the beam in the x direction",
+                                        "type": "number"
+                                    },
+                                    "y": {
+                                        "description": "The dimension of the beam in the y direction",
+                                        "type": "number"
+                                    },
+                                    "units": {
+                                        "description": "The units used to report the beam size",
+                                        "type": "string"
+                                    }
+                                }
+                            },
+                            "Take-off angle": {
+                                "description": "The angle in degree between the sample's surface normal vector and the analyzer's lens axis",
+                                "type": "number"
+                            },
+                            "Analyzer acceptance angle": {
+                                "description": "The acceptance angle in degrees of the spectrometer during the measurement of the dataset",
+                                "type": "number"
+                            },
+                            "Entrance slit": {
+                                "descritpion": "The size of the entrance aperture to the analyzer in units of mm",
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "UserID": {
+                        "description": "A unique reference to the user who uploaded the data",
+                        "$ref": "#userid"
+                    },
+                    "SampleID": {
+                        "description": "A reference to the sample from which the dataset was measured",
+                        "$ref": "#sampleid"
+                    }
+                },
+                "required": [
+                    "DatasetID",
+                    "SampleID",
+                    "UserID",
+                    "Date measured",
+                    "Spectra",
+                    "SpectrometerID"
+                ]
+            },
+            "Calibration": {
+                "Instrument calibration": {
+                    "description": "Information on the calibration procedure used to calibrate the instrument",
+                    "type": "object",
+                    "properties": {
+                        "Protocol": {
+                            "description": "The protocol used for calibrating the spectrometer",
+                            "type": "string",
+                            "enum": [
+                                "ISO 15472:2010",
+                                "ISO 15472:2001"
+                            ]
+                        },
+                        "Values": {
+                            "description": "The binding energy values obtained from the calibrated spectrometer of the standard elements",
+                            "type": "array",
+                            "items": {
+                                "type": "object",
+                                "properties": {
+                                    "Emission line": {
+                                        "description": "The emission line used for calibration",
+                                        "type": "string",
+                                        "enum": [
+                                            "Au4f7/2",
+                                            "Cu2p3/2",
+                                            "Ag3d5/2",
+                                            "Fermi"
+                                        ]
+                                    },
+                                    "Binding energy": {
+                                        "description": "The calibrated binding energy value of the specified emission line in units of eV",
+                                        "type": "number"
+                                    }
+                                }
+                            },
+                            "minItems": 1,
+                            "uniqueItems": true
+                        },
+                        "Calibration date": {
+                            "description": "The date the calibration was performed",
+                            "type": "date"
+                        },
+                        "DatasetID": {
+                            "description": "A link to the dataset",
+                            "$ref": "#datasetid"
+                        }
+                    }
+                },
+                "Binding energy reference": {
+                    "description": "binding energy scale adjustment, used in cases where samples are not conductive",
+                    "type": "object",
+                    "properties": {
+                        "Emission line": {
+                            "type": "string",
+                            "enum": [
+                                "C1s",
+                                "O1s",
+                                "Au4f7/2"
+                            ]
+                        },
+                        "Binding energy": {
+                            "description": "The binding energy that the specified emission line appeard at, after adjusting the binding energy scale, in units of eV",
+                            "type": "number"
+                        }
+                    }
+                }
+            },
+            "User": {
+                "description": "Metadata of a registered user in the system",
+                "type": "object",
+                "properties": {
+                    "UserID": {
+                        "description": "A unique identifier of the user",
+                        "$id": "#userid",
+                        "type": "integer"
+                    },
+                    "Given name": {
+                        "description": "The given name of the user",
+                        "type": "string"
+                    },
+                    "Family name": {
+                        "description": "The family name of the user",
+                        "type": "string"
+                    },
+                    "Email": {
+                        "description": "Email addresses of the user",
+                        "type": "array",
+                        "items": {
+                            "description": "email addresses",
+                            "type": "string"
+                        },
+                        "minItems": 1,
+                        "uniqueItems": true
+                    },
+                    "Laboratories": {
+                        "description": "A list of laboratories that the user is affiliated with",
+                        "type": "array",
+                        "items": {"$ref": "#laboratoryid"},
+                        "minItems": 0,
+                        "uniqueItems": true
+                    },
+                    "Instruments": {
+                        "description": "A list of spectrometers associated with the user",
+                        "type": "array",
+                        "items": {"$ref": "#instrumentid"},
+                        "minItems": 0,
+                        "uniqueItems": true
+                    },
+                    "Uploaded datasets": {
+                        "description": "A list of datasets uploaded by the user",
+                        "type": "array",
+                        "items": {"$ref": "#datasetid"},
+                        "minItems": 0,
+                        "uniqueItems": true
+                    },
+                    "Favorite datasets": {
+                        "description": "A list of datasets that the user has marked as favorite",
+                        "type": "array",
+                        "items": {"$ref": "#datasetid"},
+                        "minItems": 0,
+                        "uniqueItems": true
+                    }
+                }
+            },
+            "VAMAS": {
+                "description": "Metadata contained in the VAMAS file format",
+                "type": "object",
+                "properties": {
+                    "header": {
+                        "description": "VAMAS file header",
+                        "type": "object",
+                        "properties": {
+                            "formatID": {
+                                "description": "A description of the data format standard used",
+                                "type": "string"
+                            },
+                            "instituteID": {
+                                "description": "The name of the institute from which the data came",
+                                "type": "string"
+                            },
+                            "instrumentModelID": {},
+                            "operatorID": {},
+                            "experimentID": {},
+                            "noCommentLines": {},
+                            "commentLines": {},
+                            "expMode": {
+                                "description": "A keyword that denotes what kind of experiment was performed in the dataset. If the keyword is MAP, then each spectrum was measured from a point on a 2D spatial array. If SDP each spectrum refers to a specific layer in a depth profile. If MAPDP, each spectrum refers to a spectrum in a map and at a specific depth in a depth profile. If NORM, each spectrum may be independant from the others.",
+                                "type": "string",
+                                "ennum": [
+                                    "MAP",
+                                    "SDP",
+                                    "MAPDP",
+                                    "NORM",
+                                    "MAPSV",
+                                    "SDPSV",
+                                    "SEM",
+                                    "MAPSVDP"
+                                ],
+                                "default": "NORM"
+                            },
+                            "scanMode": {
+                                "description": "A keyword that specifies whether the abscissa values have a constant spacing, an irregular spacing, or whether the data is a map",
+                                "type": "string",
+                                "enum": [
+                                    "REGULAR",
+                                    "IRREGULAR",
+                                    "MAPPING"
+                                ]
+                            },
+                            "expVarLabel": {},
+                            "expVarUnit": {},
+                            "noBlocks": {}
+                        }
+                    },
+                    "block": {
+                        "description": "A collection of spectral data and metadata",
+                        "type": "object",
+                        "properties": {
+                            "blockID": {
+                                "description": "The name of the data block",
+                                "type": "string",
+                                "$id": "#vamasblockid"
+                            },
+                            "sampleID": {
+                                "description": "The name of the sample",
+                                "type": "string",
+                                "$id": "#vamassampleid"
+                            },
+                            "year": {"$id": "#vamasyear"},
+                            "month": {"$id": "#vamasmonth"},
+                            "day": {"$id": "#vamasday"},
+                            "hour": {},
+                            "minute": {},
+                            "second": {},
+                            "noHrsInAdvanceOfGMT": {},
+                            "noCommentLines": {},
+                            "technique": {
+                                "description": "A keyword that specifies the technique used to measure the data",
+                                "type": "string",
+                                "enum": [
+                                    "XPS",
+                                    "AES diff",
+                                    "AES dir",
+                                    "EDX",
+                                    "ELS",
+                                    "FABMS",
+                                    "ISS",
+                                    "SIMS",
+                                    "SNMS",
+                                    "UPS",
+                                    "XRF"
+                                ]
+                            },
+                            "expVarValue": {},
+                            "sourceLabel": {},
+                            "sourceEnergy": {
+                                "description": "The energy of the excitation source in eV",
+                                "type": "number",
+                                "$id": "#vamassourceenergy"
+                            },
+                            "sourceAnalyzerAngle": {
+                                "description": "The angle between the excitation source and the analyzer lens axis",
+                                "type": "number",
+                                "$id": "#vamassourceanalyzerangle"
+                            },
+                            "analyzerMode": {
+                                "description": "Measurement mode of the analyzer",
+                                "type": "string",
+                                "enum": [
+                                    "FAT",
+                                    "FRR"
+                                ],
+                                "$id": "#vamasanalyzermode"
+                            },
+                            "resolution": {
+                                "description": "The resolution of the instrument during spectrum measurement. For XPS it corresponds to pass energy",
+                                "type": "number",
+                                "$id": "#vamasresolution"
+                            },
+                            "magnification": {},
+                            "workfunction": {},
+                            "targetBias": {},
+                            "analyzerWidthX": {},
+                            "analyzerWidthY": {},
+                            "analyzerTakeOffPolarAngle": {},
+                            "analyzerAzimuth": {},
+                            "speciesLabel": {
+                                "description": "A label to identify the element of the specrtrum",
+                                "type": "string",
+                                "$id": "#vamasspecieslabel"
+                            },
+                            "transitionLabel": {
+                                "description": "A label that specifies the transition, a.k.a. emission line",
+                                "type": "string",
+                                "$id": "#vamastransitionlabel"
+                            },
+                            "particleCharge": {},
+                            "abscissaLabel": {
+                                "description": "The variable name for the abscissa data",
+                                "type": "string",
+                                "enum": [
+                                    "kinetic energy",
+                                    "binding energy"
+                                ],
+                                "$id": "#vamasabscissalabel"
+                            },
+                            "abscissaUnits": {
+                                "description": "The units used for the abscicca data",
+                                "type": "string",
+                                "$ref": "#units",
+                                "$id": "#vamasabscissaunits"
+                            },
+                            "abscissaStart": {},
+                            "abscissaStep": {
+                                "description": "Step size of the abscissa",
+                                "type": "number",
+                                "$id": "#vamasstep"
+                            },
+                            "noVariables": {},
+                            "variableLabel1": {
+                                "description": "The label of the ordinate data",
+                                "type": "string",
+                                "$id": "#vamasvar1label"
+                            },
+                            "variableUnits1": {
+                                "description": "The units used for the first experimental variable",
+                                "type": "string",
+                                "$ref": "#units"
+                            },
+                            "variableLabel2": {},
+                            "variableUnits2": {
+                                "description": "The units used for the second experimental variable",
+                                "type": "string",
+                                "$ref": "#units"
+                            },
+                            "signalMode": {
+                                "description": "The signal counting mode used to measure the data",
+                                "type": "string",
+                                "enum": [
+                                    "analogue",
+                                    "pulse counting"
+                                ]
+                            },
+                            "dwellTime": {
+                                "description": "The integration time used for each abscicca value",
+                                "type": "number",
+                                "$id": "#vamasdwelltime"
+                            },
+                            "noScans": {
+                                "description": "The number of scans used to make the spectrum",
+                                "type": "integer",
+                                "$id": "#vamasnoscans"
+                            },
+                            "timeCorrection": {},
+                            "sampleAngleTilt": {},
+                            "sampleTiltAzimuth": {},
+                            "sampleRotation": {},
+                            "noAdditionalParameters": {},
+                            "paramLabel1": {},
+                            "paramUnit1": {},
+                            "paramValue1": {},
+                            "paramLabel2": {},
+                            "paramUnit2": {},
+                            "paramValue2": {},
+                            "numOrdValues": {},
+                            "minOrdValue1": {},
+                            "maxOrdValue1": {},
+                            "minOrdValue2": {},
+                            "maxOrdValue2": {},
+                            "dataString": {
+                                "description": "The numerical data of the spectrum",
+                                "type": "array",
+                                "items": {"type": "number"}
+                            }
+                        }
+                    }
+                }
+            },
+            "Units": {
+                "description": "The physical units used for measured properties. The abreviations have the following meanings. 'c/s': counts per second, 'd': dimensionless, 'degree': angle in degrees, 'eV': electronvolts, 'K': Kelvin, 'micro C':microcoulombs, 'micro m': micrometers, 'm/s':meters per second, 'n': not defined, 'nA': nanoamps, 'ps': picoseconds, 's':seconds, 'u': unified atomic mass units, 'V':volts",
+                "type": "string",
+                "enum": [
+                    "eV",
+                    "u",
+                    "s",
+                    "c/s",
+                    "d",
+                    "degree",
+                    "K",
+                    "micro C",
+                    "micro m",
+                    "m/s",
+                    "n",
+                    "nA",
+                    "ps",
+                    "u",
+                    "V"
+                ],
+                "$id": "#units"
+            },
+            "Emission lines": {
+                "description": "All the allowed values for emission line labels",
+                "type": "array",
+                "$id": "#emissionlines",
+                "items": {"enum": [
+                    [
+                        "Ac",
+                        "4d"
+                    ],
+                    [
+                        "Ac",
+                        "4d3/2"
+                    ],
+                    [
+                        "Ac",
+                        "4d5/2"
+                    ],
+                    [
+                        "Ac",
+                        "4f"
+                    ],
+                    [
+                        "Ac",
+                        "4f5/2"
+                    ],
+                    [
+                        "Ac",
+                        "4f7/2"
+                    ],
+                    [
+                        "Ac",
+                        "4p"
+                    ],
+                    [
+                        "Ac",
+                        "4p1/2"
+                    ],
+                    [
+                        "Ac",
+                        "4p3/2"
+                    ],
+                    [
+                        "Ac",
+                        "5d"
+                    ],
+                    [
+                        "Ac",
+                        "5d3/2"
+                    ],
+                    [
+                        "Ac",
+                        "5d5/2"
+                    ],
+                    [
+                        "Ac",
+                        "5p"
+                    ],
+                    [
+                        "Ac",
+                        "5p1/2"
+                    ],
+                    [
+                        "Ac",
+                        "5p3/2"
+                    ],
+                    [
+                        "Ac",
+                        "5s"
+                    ],
+                    [
+                        "Ag",
+                        "3d"
+                    ],
+                    [
+                        "Ag",
+                        "3d3/2"
+                    ],
+                    [
+                        "Ag",
+                        "3d5/2"
+                    ],
+                    [
+                        "Ag",
+                        "3p"
+                    ],
+                    [
+                        "Ag",
+                        "3p1/2"
+                    ],
+                    [
+                        "Ag",
+                        "3p3/2"
+                    ],
+                    [
+                        "Ag",
+                        "3s"
+                    ],
+                    [
+                        "Ag",
+                        "4d"
+                    ],
+                    [
+                        "Ag",
+                        "4d3/2"
+                    ],
+                    [
+                        "Ag",
+                        "4d5/2"
+                    ],
+                    [
+                        "Ag",
+                        "4p"
+                    ],
+                    [
+                        "Ag",
+                        "4p1/2"
+                    ],
+                    [
+                        "Ag",
+                        "4p3/2"
+                    ],
+                    [
+                        "Ag",
+                        "4s"
+                    ],
+                    [
+                        "Ag",
+                        "MNN"
+                    ],
+                    [
+                        "Al",
+                        "2p"
+                    ],
+                    [
+                        "Al",
+                        "2p1/2"
+                    ],
+                    [
+                        "Al",
+                        "2p3/2"
+                    ],
+                    [
+                        "Al",
+                        "2s"
+                    ],
+                    [
+                        "Al",
+                        "3s"
+                    ],
+                    [
+                        "Al",
+                        "KLL"
+                    ],
+                    [
+                        "Al",
+                        "LMM"
+                    ],
+                    [
+                        "Ar",
+                        "2p"
+                    ],
+                    [
+                        "Ar",
+                        "2p1/2"
+                    ],
+                    [
+                        "Ar",
+                        "2p3/2"
+                    ],
+                    [
+                        "Ar",
+                        "2s"
+                    ],
+                    [
+                        "Ar",
+                        "3p"
+                    ],
+                    [
+                        "Ar",
+                        "3p1/2"
+                    ],
+                    [
+                        "Ar",
+                        "3p3/2"
+                    ],
+                    [
+                        "Ar",
+                        "3s"
+                    ],
+                    [
+                        "Ar",
+                        "LMM"
+                    ],
+                    [
+                        "As",
+                        "3d"
+                    ],
+                    [
+                        "As",
+                        "3d3/2"
+                    ],
+                    [
+                        "As",
+                        "3d5/2"
+                    ],
+                    [
+                        "As",
+                        "3p"
+                    ],
+                    [
+                        "As",
+                        "3p1/2"
+                    ],
+                    [
+                        "As",
+                        "3p3/2"
+                    ],
+                    [
+                        "As",
+                        "3s"
+                    ],
+                    [
+                        "As",
+                        "4p"
+                    ],
+                    [
+                        "As",
+                        "4p1/2"
+                    ],
+                    [
+                        "As",
+                        "4p3/2"
+                    ],
+                    [
+                        "As",
+                        "LMM"
+                    ],
+                    [
+                        "At",
+                        "4d"
+                    ],
+                    [
+                        "At",
+                        "4d3/2"
+                    ],
+                    [
+                        "At",
+                        "4d5/2"
+                    ],
+                    [
+                        "At",
+                        "4f"
+                    ],
+                    [
+                        "At",
+                        "4f5/2"
+                    ],
+                    [
+                        "At",
+                        "4f7/2"
+                    ],
+                    [
+                        "At",
+                        "4p"
+                    ],
+                    [
+                        "At",
+                        "4p1/2"
+                    ],
+                    [
+                        "At",
+                        "4p3/2"
+                    ],
+                    [
+                        "At",
+                        "4s"
+                    ],
+                    [
+                        "At",
+                        "5d"
+                    ],
+                    [
+                        "At",
+                        "5d3/2"
+                    ],
+                    [
+                        "At",
+                        "5d5/2"
+                    ],
+                    [
+                        "At",
+                        "5p"
+                    ],
+                    [
+                        "At",
+                        "5p1/2"
+                    ],
+                    [
+                        "At",
+                        "5p3/2"
+                    ],
+                    [
+                        "At",
+                        "5s"
+                    ],
+                    [
+                        "At",
+                        "6p"
+                    ],
+                    [
+                        "At",
+                        "6p1/2"
+                    ],
+                    [
+                        "At",
+                        "6p3/2"
+                    ],
+                    [
+                        "At",
+                        "6s"
+                    ],
+                    [
+                        "Au",
+                        "4d"
+                    ],
+                    [
+                        "Au",
+                        "4d3/2"
+                    ],
+                    [
+                        "Au",
+                        "4d5/2"
+                    ],
+                    [
+                        "Au",
+                        "4f"
+                    ],
+                    [
+                        "Au",
+                        "4f5/2"
+                    ],
+                    [
+                        "Au",
+                        "4f7/2"
+                    ],
+                    [
+                        "Au",
+                        "4p"
+                    ],
+                    [
+                        "Au",
+                        "4p1/2"
+                    ],
+                    [
+                        "Au",
+                        "4p3/2"
+                    ],
+                    [
+                        "Au",
+                        "4s"
+                    ],
+                    [
+                        "Au",
+                        "5d"
+                    ],
+                    [
+                        "Au",
+                        "5d3/2"
+                    ],
+                    [
+                        "Au",
+                        "5d5/2"
+                    ],
+                    [
+                        "Au",
+                        "5p"
+                    ],
+                    [
+                        "Au",
+                        "5p1/2"
+                    ],
+                    [
+                        "Au",
+                        "5p3/2"
+                    ],
+                    [
+                        "Au",
+                        "5s"
+                    ],
+                    [
+                        "Au",
+                        "MNN"
+                    ],
+                    [
+                        "Au",
+                        "NOO"
+                    ],
+                    [
+                        "B",
+                        "1s"
+                    ],
+                    [
+                        "B",
+                        "2p"
+                    ],
+                    [
+                        "B",
+                        "2p1/2"
+                    ],
+                    [
+                        "B",
+                        "2p3/2"
+                    ],
+                    [
+                        "B",
+                        "KLL"
+                    ],
+                    [
+                        "Ba",
+                        "3d"
+                    ],
+                    [
+                        "Ba",
+                        "3d3/2"
+                    ],
+                    [
+                        "Ba",
+                        "3d5/2"
+                    ],
+                    [
+                        "Ba",
+                        "3p"
+                    ],
+                    [
+                        "Ba",
+                        "3p1/2"
+                    ],
+                    [
+                        "Ba",
+                        "3p3/2"
+                    ],
+                    [
+                        "Ba",
+                        "4d"
+                    ],
+                    [
+                        "Ba",
+                        "4d3/2"
+                    ],
+                    [
+                        "Ba",
+                        "4d5/2"
+                    ],
+                    [
+                        "Ba",
+                        "4p"
+                    ],
+                    [
+                        "Ba",
+                        "4p1/2"
+                    ],
+                    [
+                        "Ba",
+                        "4p3/2"
+                    ],
+                    [
+                        "Ba",
+                        "4s"
+                    ],
+                    [
+                        "Ba",
+                        "5p"
+                    ],
+                    [
+                        "Ba",
+                        "5p1/2"
+                    ],
+                    [
+                        "Ba",
+                        "5p3/2"
+                    ],
+                    [
+                        "Ba",
+                        "5s"
+                    ],
+                    [
+                        "Ba",
+                        "MNN"
+                    ],
+                    [
+                        "Be",
+                        "1s"
+                    ],
+                    [
+                        "Be",
+                        "KLL"
+                    ],
+                    [
+                        "Bi",
+                        "4d"
+                    ],
+                    [
+                        "Bi",
+                        "4d3/2"
+                    ],
+                    [
+                        "Bi",
+                        "4d5/2"
+                    ],
+                    [
+                        "Bi",
+                        "4f"
+                    ],
+                    [
+                        "Bi",
+                        "4f5/2"
+                    ],
+                    [
+                        "Bi",
+                        "4f7/2"
+                    ],
+                    [
+                        "Bi",
+                        "4p"
+                    ],
+                    [
+                        "Bi",
+                        "4p1/2"
+                    ],
+                    [
+                        "Bi",
+                        "4p3/2"
+                    ],
+                    [
+                        "Bi",
+                        "4s"
+                    ],
+                    [
+                        "Bi",
+                        "5d"
+                    ],
+                    [
+                        "Bi",
+                        "5d3/2"
+                    ],
+                    [
+                        "Bi",
+                        "5d5/2"
+                    ],
+                    [
+                        "Bi",
+                        "5p"
+                    ],
+                    [
+                        "Bi",
+                        "5p1/2"
+                    ],
+                    [
+                        "Bi",
+                        "5p3/2"
+                    ],
+                    [
+                        "Bi",
+                        "5s"
+                    ],
+                    [
+                        "Bi",
+                        "6p"
+                    ],
+                    [
+                        "Bi",
+                        "6p1/2"
+                    ],
+                    [
+                        "Bi",
+                        "6p3/2"
+                    ],
+                    [
+                        "Bi",
+                        "6s"
+                    ],
+                    [
+                        "Br",
+                        "3d"
+                    ],
+                    [
+                        "Br",
+                        "3d3/2"
+                    ],
+                    [
+                        "Br",
+                        "3d5/2"
+                    ],
+                    [
+                        "Br",
+                        "3p"
+                    ],
+                    [
+                        "Br",
+                        "3p1/2"
+                    ],
+                    [
+                        "Br",
+                        "3p3/2"
+                    ],
+                    [
+                        "Br",
+                        "3s"
+                    ],
+                    [
+                        "Br",
+                        "4p"
+                    ],
+                    [
+                        "Br",
+                        "4p1/2"
+                    ],
+                    [
+                        "Br",
+                        "4p3/2"
+                    ],
+                    [
+                        "Br",
+                        "4s"
+                    ],
+                    [
+                        "Br",
+                        "LMM"
+                    ],
+                    [
+                        "Br",
+                        "MNN"
+                    ],
+                    [
+                        "C",
+                        "1s"
+                    ],
+                    [
+                        "C",
+                        "2p"
+                    ],
+                    [
+                        "C",
+                        "2p1/2"
+                    ],
+                    [
+                        "C",
+                        "2p3/2"
+                    ],
+                    [
+                        "C",
+                        "KLL"
+                    ],
+                    [
+                        "Ca",
+                        "2p"
+                    ],
+                    [
+                        "Ca",
+                        "2p1/2"
+                    ],
+                    [
+                        "Ca",
+                        "2p3/2"
+                    ],
+                    [
+                        "Ca",
+                        "2s"
+                    ],
+                    [
+                        "Ca",
+                        "3p"
+                    ],
+                    [
+                        "Ca",
+                        "3p1/2"
+                    ],
+                    [
+                        "Ca",
+                        "3p3/2"
+                    ],
+                    [
+                        "Ca",
+                        "3s"
+                    ],
+                    [
+                        "Ca",
+                        "LMM"
+                    ],
+                    [
+                        "Cd",
+                        "3d"
+                    ],
+                    [
+                        "Cd",
+                        "3d3/2"
+                    ],
+                    [
+                        "Cd",
+                        "3d5/2"
+                    ],
+                    [
+                        "Cd",
+                        "3p"
+                    ],
+                    [
+                        "Cd",
+                        "3p1/2"
+                    ],
+                    [
+                        "Cd",
+                        "3p3/2"
+                    ],
+                    [
+                        "Cd",
+                        "3s"
+                    ],
+                    [
+                        "Cd",
+                        "4d"
+                    ],
+                    [
+                        "Cd",
+                        "4d3/2"
+                    ],
+                    [
+                        "Cd",
+                        "4d5/2"
+                    ],
+                    [
+                        "Cd",
+                        "4p"
+                    ],
+                    [
+                        "Cd",
+                        "4p1/2"
+                    ],
+                    [
+                        "Cd",
+                        "4p3/2"
+                    ],
+                    [
+                        "Cd",
+                        "4s"
+                    ],
+                    [
+                        "Cd",
+                        "MNN"
+                    ],
+                    [
+                        "Ce",
+                        "3d"
+                    ],
+                    [
+                        "Ce",
+                        "3d3/2"
+                    ],
+                    [
+                        "Ce",
+                        "3d5/2"
+                    ],
+                    [
+                        "Ce",
+                        "3p"
+                    ],
+                    [
+                        "Ce",
+                        "3p3/2"
+                    ],
+                    [
+                        "Ce",
+                        "4d"
+                    ],
+                    [
+                        "Ce",
+                        "4d3/2"
+                    ],
+                    [
+                        "Ce",
+                        "4d5/2"
+                    ],
+                    [
+                        "Ce",
+                        "4f"
+                    ],
+                    [
+                        "Ce",
+                        "4f5/2"
+                    ],
+                    [
+                        "Ce",
+                        "4f7/2"
+                    ],
+                    [
+                        "Ce",
+                        "4p"
+                    ],
+                    [
+                        "Ce",
+                        "4p1/2"
+                    ],
+                    [
+                        "Ce",
+                        "4p3/2"
+                    ],
+                    [
+                        "Ce",
+                        "4s"
+                    ],
+                    [
+                        "Ce",
+                        "5p"
+                    ],
+                    [
+                        "Ce",
+                        "5p1/2"
+                    ],
+                    [
+                        "Ce",
+                        "5p3/2"
+                    ],
+                    [
+                        "Ce",
+                        "5s"
+                    ],
+                    [
+                        "Ce",
+                        "LMM"
+                    ],
+                    [
+                        "Cl",
+                        "2p"
+                    ],
+                    [
+                        "Cl",
+                        "2p1/2"
+                    ],
+                    [
+                        "Cl",
+                        "2p3/2"
+                    ],
+                    [
+                        "Cl",
+                        "2s"
+                    ],
+                    [
+                        "Cl",
+                        "3p"
+                    ],
+                    [
+                        "Cl",
+                        "3p1/2"
+                    ],
+                    [
+                        "Cl",
+                        "3p3/2"
+                    ],
+                    [
+                        "Cl",
+                        "3s"
+                    ],
+                    [
+                        "Cl",
+                        "LMM"
+                    ],
+                    [
+                        "Co",
+                        "2p"
+                    ],
+                    [
+                        "Co",
+                        "2p1/2"
+                    ],
+                    [
+                        "Co",
+                        "2p3/2"
+                    ],
+                    [
+                        "Co",
+                        "2s"
+                    ],
+                    [
+                        "Co",
+                        "3d"
+                    ],
+                    [
+                        "Co",
+                        "3d3/2"
+                    ],
+                    [
+                        "Co",
+                        "3d5/2"
+                    ],
+                    [
+                        "Co",
+                        "3p"
+                    ],
+                    [
+                        "Co",
+                        "3p1/2"
+                    ],
+                    [
+                        "Co",
+                        "3p3/2"
+                    ],
+                    [
+                        "Co",
+                        "3s"
+                    ],
+                    [
+                        "Co",
+                        "LMM"
+                    ],
+                    [
+                        "Cr",
+                        "2p"
+                    ],
+                    [
+                        "Cr",
+                        "2p1/2"
+                    ],
+                    [
+                        "Cr",
+                        "2p3/2"
+                    ],
+                    [
+                        "Cr",
+                        "2s"
+                    ],
+                    [
+                        "Cr",
+                        "3d"
+                    ],
+                    [
+                        "Cr",
+                        "3d3/2"
+                    ],
+                    [
+                        "Cr",
+                        "3d5/2"
+                    ],
+                    [
+                        "Cr",
+                        "3p"
+                    ],
+                    [
+                        "Cr",
+                        "3p1/2"
+                    ],
+                    [
+                        "Cr",
+                        "3p3/2"
+                    ],
+                    [
+                        "Cr",
+                        "3s"
+                    ],
+                    [
+                        "Cr",
+                        "LMM"
+                    ],
+                    [
+                        "Cs",
+                        "3d"
+                    ],
+                    [
+                        "Cs",
+                        "3d3/2"
+                    ],
+                    [
+                        "Cs",
+                        "3d5/2"
+                    ],
+                    [
+                        "Cs",
+                        "3p"
+                    ],
+                    [
+                        "Cs",
+                        "3p1/2"
+                    ],
+                    [
+                        "Cs",
+                        "3p3/2"
+                    ],
+                    [
+                        "Cs",
+                        "3s"
+                    ],
+                    [
+                        "Cs",
+                        "4d"
+                    ],
+                    [
+                        "Cs",
+                        "4d3/2"
+                    ],
+                    [
+                        "Cs",
+                        "4d5/2"
+                    ],
+                    [
+                        "Cs",
+                        "4p"
+                    ],
+                    [
+                        "Cs",
+                        "4p1/2"
+                    ],
+                    [
+                        "Cs",
+                        "4p3/2"
+                    ],
+                    [
+                        "Cs",
+                        "4s"
+                    ],
+                    [
+                        "Cs",
+                        "5p"
+                    ],
+                    [
+                        "Cs",
+                        "5p1/2"
+                    ],
+                    [
+                        "Cs",
+                        "5p3/2"
+                    ],
+                    [
+                        "Cs",
+                        "5s"
+                    ],
+                    [
+                        "Cs",
+                        "MNN"
+                    ],
+                    [
+                        "Cu",
+                        "2p"
+                    ],
+                    [
+                        "Cu",
+                        "2p1/2"
+                    ],
+                    [
+                        "Cu",
+                        "2p3/2"
+                    ],
+                    [
+                        "Cu",
+                        "2s"
+                    ],
+                    [
+                        "Cu",
+                        "3d"
+                    ],
+                    [
+                        "Cu",
+                        "3d3/2"
+                    ],
+                    [
+                        "Cu",
+                        "3d5/2"
+                    ],
+                    [
+                        "Cu",
+                        "3p"
+                    ],
+                    [
+                        "Cu",
+                        "3p1/2"
+                    ],
+                    [
+                        "Cu",
+                        "3p3/2"
+                    ],
+                    [
+                        "Cu",
+                        "3s"
+                    ],
+                    [
+                        "Cu",
+                        "LMM"
+                    ],
+                    [
+                        "Dy",
+                        "4d"
+                    ],
+                    [
+                        "Dy",
+                        "4d3/2"
+                    ],
+                    [
+                        "Dy",
+                        "4d5/2"
+                    ],
+                    [
+                        "Dy",
+                        "4f"
+                    ],
+                    [
+                        "Dy",
+                        "4f5/2"
+                    ],
+                    [
+                        "Dy",
+                        "4f7/2"
+                    ],
+                    [
+                        "Dy",
+                        "4p"
+                    ],
+                    [
+                        "Dy",
+                        "4p1/2"
+                    ],
+                    [
+                        "Dy",
+                        "4p3/2"
+                    ],
+                    [
+                        "Dy",
+                        "4s"
+                    ],
+                    [
+                        "Dy",
+                        "5p"
+                    ],
+                    [
+                        "Dy",
+                        "5p1/2"
+                    ],
+                    [
+                        "Dy",
+                        "5p3/2"
+                    ],
+                    [
+                        "Dy",
+                        "5s"
+                    ],
+                    [
+                        "Dy",
+                        "MVV"
+                    ],
+                    [
+                        "Er",
+                        "4d"
+                    ],
+                    [
+                        "Er",
+                        "4d3/2"
+                    ],
+                    [
+                        "Er",
+                        "4d5/2"
+                    ],
+                    [
+                        "Er",
+                        "4f"
+                    ],
+                    [
+                        "Er",
+                        "4f5/2"
+                    ],
+                    [
+                        "Er",
+                        "4f7/2"
+                    ],
+                    [
+                        "Er",
+                        "4p"
+                    ],
+                    [
+                        "Er",
+                        "4p1/2"
+                    ],
+                    [
+                        "Er",
+                        "4p3/2"
+                    ],
+                    [
+                        "Er",
+                        "4s"
+                    ],
+                    [
+                        "Er",
+                        "5p"
+                    ],
+                    [
+                        "Er",
+                        "5p1/2"
+                    ],
+                    [
+                        "Er",
+                        "5p3/2"
+                    ],
+                    [
+                        "Er",
+                        "5s"
+                    ],
+                    [
+                        "Er",
+                        "MVV"
+                    ],
+                    [
+                        "Eu",
+                        "3d"
+                    ],
+                    [
+                        "Eu",
+                        "3d3/2"
+                    ],
+                    [
+                        "Eu",
+                        "3d5/2"
+                    ],
+                    [
+                        "Eu",
+                        "4d"
+                    ],
+                    [
+                        "Eu",
+                        "4d3/2"
+                    ],
+                    [
+                        "Eu",
+                        "4d5/2"
+                    ],
+                    [
+                        "Eu",
+                        "4p"
+                    ],
+                    [
+                        "Eu",
+                        "4p1/2"
+                    ],
+                    [
+                        "Eu",
+                        "4p3/2"
+                    ],
+                    [
+                        "Eu",
+                        "4s"
+                    ],
+                    [
+                        "Eu",
+                        "5p"
+                    ],
+                    [
+                        "Eu",
+                        "5p1/2"
+                    ],
+                    [
+                        "Eu",
+                        "5p3/2"
+                    ],
+                    [
+                        "Eu",
+                        "5s"
+                    ],
+                    [
+                        "Eu",
+                        "MNN"
+                    ],
+                    [
+                        "F",
+                        "1s"
+                    ],
+                    [
+                        "F",
+                        "2p"
+                    ],
+                    [
+                        "F",
+                        "2p1/2"
+                    ],
+                    [
+                        "F",
+                        "2p3/2"
+                    ],
+                    [
+                        "F",
+                        "2s"
+                    ],
+                    [
+                        "F",
+                        "KLL"
+                    ],
+                    [
+                        "Fe",
+                        "2p"
+                    ],
+                    [
+                        "Fe",
+                        "2p1/2"
+                    ],
+                    [
+                        "Fe",
+                        "2p3/2"
+                    ],
+                    [
+                        "Fe",
+                        "2s"
+                    ],
+                    [
+                        "Fe",
+                        "3d"
+                    ],
+                    [
+                        "Fe",
+                        "3d3/2"
+                    ],
+                    [
+                        "Fe",
+                        "3d5/2"
+                    ],
+                    [
+                        "Fe",
+                        "3p"
+                    ],
+                    [
+                        "Fe",
+                        "3p1/2"
+                    ],
+                    [
+                        "Fe",
+                        "3p3/2"
+                    ],
+                    [
+                        "Fe",
+                        "3s"
+                    ],
+                    [
+                        "Fe",
+                        "LMM"
+                    ],
+                    [
+                        "Fr",
+                        "4d"
+                    ],
+                    [
+                        "Fr",
+                        "4d3/2"
+                    ],
+                    [
+                        "Fr",
+                        "4d5/2"
+                    ],
+                    [
+                        "Fr",
+                        "4f"
+                    ],
+                    [
+                        "Fr",
+                        "4f5/2"
+                    ],
+                    [
+                        "Fr",
+                        "4f7/2"
+                    ],
+                    [
+                        "Fr",
+                        "4p"
+                    ],
+                    [
+                        "Fr",
+                        "4p1/2"
+                    ],
+                    [
+                        "Fr",
+                        "4p3/2"
+                    ],
+                    [
+                        "Fr",
+                        "4s"
+                    ],
+                    [
+                        "Fr",
+                        "5d"
+                    ],
+                    [
+                        "Fr",
+                        "5d3/2"
+                    ],
+                    [
+                        "Fr",
+                        "5d5/2"
+                    ],
+                    [
+                        "Fr",
+                        "5p"
+                    ],
+                    [
+                        "Fr",
+                        "5p1/2"
+                    ],
+                    [
+                        "Fr",
+                        "5p3/2"
+                    ],
+                    [
+                        "Fr",
+                        "5s"
+                    ],
+                    [
+                        "Fr",
+                        "6p"
+                    ],
+                    [
+                        "Fr",
+                        "6p1/2"
+                    ],
+                    [
+                        "Fr",
+                        "6p3/2"
+                    ],
+                    [
+                        "Fr",
+                        "6s"
+                    ],
+                    [
+                        "Ga",
+                        "2p"
+                    ],
+                    [
+                        "Ga",
+                        "2p1/2"
+                    ],
+                    [
+                        "Ga",
+                        "2p3/2"
+                    ],
+                    [
+                        "Ga",
+                        "2s"
+                    ],
+                    [
+                        "Ga",
+                        "3d"
+                    ],
+                    [
+                        "Ga",
+                        "3d3/2"
+                    ],
+                    [
+                        "Ga",
+                        "3d5/2"
+                    ],
+                    [
+                        "Ga",
+                        "3p"
+                    ],
+                    [
+                        "Ga",
+                        "3p1/2"
+                    ],
+                    [
+                        "Ga",
+                        "3p3/2"
+                    ],
+                    [
+                        "Ga",
+                        "3s"
+                    ],
+                    [
+                        "Ga",
+                        "4p"
+                    ],
+                    [
+                        "Ga",
+                        "4p1/2"
+                    ],
+                    [
+                        "Ga",
+                        "4p3/2"
+                    ],
+                    [
+                        "Ga",
+                        "LMM"
+                    ],
+                    [
+                        "Gd",
+                        "3d"
+                    ],
+                    [
+                        "Gd",
+                        "3d3/2"
+                    ],
+                    [
+                        "Gd",
+                        "3d5/2"
+                    ],
+                    [
+                        "Gd",
+                        "4d"
+                    ],
+                    [
+                        "Gd",
+                        "4d3/2"
+                    ],
+                    [
+                        "Gd",
+                        "4d5/2"
+                    ],
+                    [
+                        "Gd",
+                        "4p"
+                    ],
+                    [
+                        "Gd",
+                        "4p1/2"
+                    ],
+                    [
+                        "Gd",
+                        "4p3/2"
+                    ],
+                    [
+                        "Gd",
+                        "4s"
+                    ],
+                    [
+                        "Gd",
+                        "5p"
+                    ],
+                    [
+                        "Gd",
+                        "5p1/2"
+                    ],
+                    [
+                        "Gd",
+                        "5p3/2"
+                    ],
+                    [
+                        "Gd",
+                        "5s"
+                    ],
+                    [
+                        "Gd",
+                        "MNN"
+                    ],
+                    [
+                        "Ge",
+                        "2p"
+                    ],
+                    [
+                        "Ge",
+                        "2p1/2"
+                    ],
+                    [
+                        "Ge",
+                        "2p3/2"
+                    ],
+                    [
+                        "Ge",
+                        "3d"
+                    ],
+                    [
+                        "Ge",
+                        "3d3/2"
+                    ],
+                    [
+                        "Ge",
+                        "3d5/2"
+                    ],
+                    [
+                        "Ge",
+                        "3p"
+                    ],
+                    [
+                        "Ge",
+                        "3p1/2"
+                    ],
+                    [
+                        "Ge",
+                        "3p3/2"
+                    ],
+                    [
+                        "Ge",
+                        "3s"
+                    ],
+                    [
+                        "Ge",
+                        "4p"
+                    ],
+                    [
+                        "Ge",
+                        "4p1/2"
+                    ],
+                    [
+                        "Ge",
+                        "4p3/2"
+                    ],
+                    [
+                        "Ge",
+                        "LMM"
+                    ],
+                    [
+                        "H",
+                        "1s"
+                    ],
+                    [
+                        "He",
+                        "1s"
+                    ],
+                    [
+                        "Hf",
+                        "4d"
+                    ],
+                    [
+                        "Hf",
+                        "4d3/2"
+                    ],
+                    [
+                        "Hf",
+                        "4d5/2"
+                    ],
+                    [
+                        "Hf",
+                        "4f"
+                    ],
+                    [
+                        "Hf",
+                        "4f5/2"
+                    ],
+                    [
+                        "Hf",
+                        "4f7/2"
+                    ],
+                    [
+                        "Hf",
+                        "4p"
+                    ],
+                    [
+                        "Hf",
+                        "4p1/2"
+                    ],
+                    [
+                        "Hf",
+                        "4p3/2"
+                    ],
+                    [
+                        "Hf",
+                        "4s"
+                    ],
+                    [
+                        "Hf",
+                        "5d"
+                    ],
+                    [
+                        "Hf",
+                        "5d3/2"
+                    ],
+                    [
+                        "Hf",
+                        "5d5/2"
+                    ],
+                    [
+                        "Hf",
+                        "5p"
+                    ],
+                    [
+                        "Hf",
+                        "5p1/2"
+                    ],
+                    [
+                        "Hf",
+                        "5p3/2"
+                    ],
+                    [
+                        "Hf",
+                        "5s"
+                    ],
+                    [
+                        "Hf",
+                        "MVV"
+                    ],
+                    [
+                        "Hg",
+                        "4d"
+                    ],
+                    [
+                        "Hg",
+                        "4d3/2"
+                    ],
+                    [
+                        "Hg",
+                        "4d5/2"
+                    ],
+                    [
+                        "Hg",
+                        "4f"
+                    ],
+                    [
+                        "Hg",
+                        "4f5/2"
+                    ],
+                    [
+                        "Hg",
+                        "4f7/2"
+                    ],
+                    [
+                        "Hg",
+                        "4p"
+                    ],
+                    [
+                        "Hg",
+                        "4p1/2"
+                    ],
+                    [
+                        "Hg",
+                        "4p3/2"
+                    ],
+                    [
+                        "Hg",
+                        "4s"
+                    ],
+                    [
+                        "Hg",
+                        "5d"
+                    ],
+                    [
+                        "Hg",
+                        "5d3/2"
+                    ],
+                    [
+                        "Hg",
+                        "5d5/2"
+                    ],
+                    [
+                        "Hg",
+                        "5p"
+                    ],
+                    [
+                        "Hg",
+                        "5p1/2"
+                    ],
+                    [
+                        "Hg",
+                        "5p3/2"
+                    ],
+                    [
+                        "Hg",
+                        "5s"
+                    ],
+                    [
+                        "Hg",
+                        "MNN"
+                    ],
+                    [
+                        "Ho",
+                        "4d"
+                    ],
+                    [
+                        "Ho",
+                        "4d3/2"
+                    ],
+                    [
+                        "Ho",
+                        "4d5/2"
+                    ],
+                    [
+                        "Ho",
+                        "4f"
+                    ],
+                    [
+                        "Ho",
+                        "4f5/2"
+                    ],
+                    [
+                        "Ho",
+                        "4f7/2"
+                    ],
+                    [
+                        "Ho",
+                        "4p"
+                    ],
+                    [
+                        "Ho",
+                        "4p1/2"
+                    ],
+                    [
+                        "Ho",
+                        "4p3/2"
+                    ],
+                    [
+                        "Ho",
+                        "4s"
+                    ],
+                    [
+                        "Ho",
+                        "5p"
+                    ],
+                    [
+                        "Ho",
+                        "5p1/2"
+                    ],
+                    [
+                        "Ho",
+                        "5p3/2"
+                    ],
+                    [
+                        "Ho",
+                        "5s"
+                    ],
+                    [
+                        "Ho",
+                        "MVV"
+                    ],
+                    [
+                        "I",
+                        "3d"
+                    ],
+                    [
+                        "I",
+                        "3d3/2"
+                    ],
+                    [
+                        "I",
+                        "3d5/2"
+                    ],
+                    [
+                        "I",
+                        "3p"
+                    ],
+                    [
+                        "I",
+                        "3p1/2"
+                    ],
+                    [
+                        "I",
+                        "3p3/2"
+                    ],
+                    [
+                        "I",
+                        "3s"
+                    ],
+                    [
+                        "I",
+                        "4d"
+                    ],
+                    [
+                        "I",
+                        "4d3/2"
+                    ],
+                    [
+                        "I",
+                        "4d5/2"
+                    ],
+                    [
+                        "I",
+                        "4p"
+                    ],
+                    [
+                        "I",
+                        "4p1/2"
+                    ],
+                    [
+                        "I",
+                        "4p3/2"
+                    ],
+                    [
+                        "I",
+                        "4s"
+                    ],
+                    [
+                        "I",
+                        "5p"
+                    ],
+                    [
+                        "I",
+                        "5p1/2"
+                    ],
+                    [
+                        "I",
+                        "5p3/2"
+                    ],
+                    [
+                        "I",
+                        "5s"
+                    ],
+                    [
+                        "I",
+                        "MNN"
+                    ],
+                    [
+                        "In",
+                        "3d"
+                    ],
+                    [
+                        "In",
+                        "3d3/2"
+                    ],
+                    [
+                        "In",
+                        "3d5/2"
+                    ],
+                    [
+                        "In",
+                        "3p"
+                    ],
+                    [
+                        "In",
+                        "3p1/2"
+                    ],
+                    [
+                        "In",
+                        "3p3/2"
+                    ],
+                    [
+                        "In",
+                        "3s"
+                    ],
+                    [
+                        "In",
+                        "4d"
+                    ],
+                    [
+                        "In",
+                        "4d3/2"
+                    ],
+                    [
+                        "In",
+                        "4d5/2"
+                    ],
+                    [
+                        "In",
+                        "4p"
+                    ],
+                    [
+                        "In",
+                        "4p1/2"
+                    ],
+                    [
+                        "In",
+                        "4p3/2"
+                    ],
+                    [
+                        "In",
+                        "4s"
+                    ],
+                    [
+                        "In",
+                        "5p"
+                    ],
+                    [
+                        "In",
+                        "5p1/2"
+                    ],
+                    [
+                        "In",
+                        "5p3/2"
+                    ],
+                    [
+                        "In",
+                        "MNN"
+                    ],
+                    [
+                        "Ir",
+                        "4d"
+                    ],
+                    [
+                        "Ir",
+                        "4d3/2"
+                    ],
+                    [
+                        "Ir",
+                        "4d5/2"
+                    ],
+                    [
+                        "Ir",
+                        "4f"
+                    ],
+                    [
+                        "Ir",
+                        "4f5/2"
+                    ],
+                    [
+                        "Ir",
+                        "4f7/2"
+                    ],
+                    [
+                        "Ir",
+                        "4p"
+                    ],
+                    [
+                        "Ir",
+                        "4p1/2"
+                    ],
+                    [
+                        "Ir",
+                        "4p3/2"
+                    ],
+                    [
+                        "Ir",
+                        "4s"
+                    ],
+                    [
+                        "Ir",
+                        "5d"
+                    ],
+                    [
+                        "Ir",
+                        "5d3/2"
+                    ],
+                    [
+                        "Ir",
+                        "5d5/2"
+                    ],
+                    [
+                        "Ir",
+                        "5p"
+                    ],
+                    [
+                        "Ir",
+                        "5p1/2"
+                    ],
+                    [
+                        "Ir",
+                        "5p3/2"
+                    ],
+                    [
+                        "Ir",
+                        "5s"
+                    ],
+                    [
+                        "K",
+                        "2p"
+                    ],
+                    [
+                        "K",
+                        "2p1/2"
+                    ],
+                    [
+                        "K",
+                        "2p3/2"
+                    ],
+                    [
+                        "K",
+                        "2s"
+                    ],
+                    [
+                        "K",
+                        "3p"
+                    ],
+                    [
+                        "K",
+                        "3p1/2"
+                    ],
+                    [
+                        "K",
+                        "3p3/2"
+                    ],
+                    [
+                        "K",
+                        "3s"
+                    ],
+                    [
+                        "K",
+                        "LMM"
+                    ],
+                    [
+                        "Kr",
+                        "3d"
+                    ],
+                    [
+                        "Kr",
+                        "3d3/2"
+                    ],
+                    [
+                        "Kr",
+                        "3d5/2"
+                    ],
+                    [
+                        "Kr",
+                        "3p"
+                    ],
+                    [
+                        "Kr",
+                        "3p1/2"
+                    ],
+                    [
+                        "Kr",
+                        "3p3/2"
+                    ],
+                    [
+                        "Kr",
+                        "3s"
+                    ],
+                    [
+                        "Kr",
+                        "4p"
+                    ],
+                    [
+                        "Kr",
+                        "4p1/2"
+                    ],
+                    [
+                        "Kr",
+                        "4p3/2"
+                    ],
+                    [
+                        "Kr",
+                        "4s"
+                    ],
+                    [
+                        "La",
+                        "3d"
+                    ],
+                    [
+                        "La",
+                        "3d3/2"
+                    ],
+                    [
+                        "La",
+                        "3d5/2"
+                    ],
+                    [
+                        "La",
+                        "3p"
+                    ],
+                    [
+                        "La",
+                        "3p1/2"
+                    ],
+                    [
+                        "La",
+                        "3p3/2"
+                    ],
+                    [
+                        "La",
+                        "4d"
+                    ],
+                    [
+                        "La",
+                        "4d3/2"
+                    ],
+                    [
+                        "La",
+                        "4d5/2"
+                    ],
+                    [
+                        "La",
+                        "4p"
+                    ],
+                    [
+                        "La",
+                        "4p1/2"
+                    ],
+                    [
+                        "La",
+                        "4p3/2"
+                    ],
+                    [
+                        "La",
+                        "4s"
+                    ],
+                    [
+                        "La",
+                        "5p"
+                    ],
+                    [
+                        "La",
+                        "5p1/2"
+                    ],
+                    [
+                        "La",
+                        "5p3/2"
+                    ],
+                    [
+                        "La",
+                        "5s"
+                    ],
+                    [
+                        "La",
+                        "MNN"
+                    ],
+                    [
+                        "Li",
+                        "1s"
+                    ],
+                    [
+                        "Lu",
+                        "4d"
+                    ],
+                    [
+                        "Lu",
+                        "4d3/2"
+                    ],
+                    [
+                        "Lu",
+                        "4d5/2"
+                    ],
+                    [
+                        "Lu",
+                        "4f"
+                    ],
+                    [
+                        "Lu",
+                        "4f5/2"
+                    ],
+                    [
+                        "Lu",
+                        "4f7/2"
+                    ],
+                    [
+                        "Lu",
+                        "4p"
+                    ],
+                    [
+                        "Lu",
+                        "4p1/2"
+                    ],
+                    [
+                        "Lu",
+                        "4p3/2"
+                    ],
+                    [
+                        "Lu",
+                        "4s"
+                    ],
+                    [
+                        "Lu",
+                        "5d"
+                    ],
+                    [
+                        "Lu",
+                        "5d3/2"
+                    ],
+                    [
+                        "Lu",
+                        "5d5/2"
+                    ],
+                    [
+                        "Lu",
+                        "5p"
+                    ],
+                    [
+                        "Lu",
+                        "5p1/2"
+                    ],
+                    [
+                        "Lu",
+                        "5p3/2"
+                    ],
+                    [
+                        "Lu",
+                        "5s"
+                    ],
+                    [
+                        "Lu",
+                        "MVV"
+                    ],
+                    [
+                        "Mg",
+                        "1s"
+                    ],
+                    [
+                        "Mg",
+                        "2p"
+                    ],
+                    [
+                        "Mg",
+                        "2p1/2"
+                    ],
+                    [
+                        "Mg",
+                        "2p3/2"
+                    ],
+                    [
+                        "Mg",
+                        "2s"
+                    ],
+                    [
+                        "Mg",
+                        "3s"
+                    ],
+                    [
+                        "Mg",
+                        "KLL"
+                    ],
+                    [
+                        "Mn",
+                        "2p"
+                    ],
+                    [
+                        "Mn",
+                        "2p1/2"
+                    ],
+                    [
+                        "Mn",
+                        "2p3/2"
+                    ],
+                    [
+                        "Mn",
+                        "2s"
+                    ],
+                    [
+                        "Mn",
+                        "3d"
+                    ],
+                    [
+                        "Mn",
+                        "3d3/2"
+                    ],
+                    [
+                        "Mn",
+                        "3d5/2"
+                    ],
+                    [
+                        "Mn",
+                        "3p"
+                    ],
+                    [
+                        "Mn",
+                        "3p1/2"
+                    ],
+                    [
+                        "Mn",
+                        "3p3/2"
+                    ],
+                    [
+                        "Mn",
+                        "3s"
+                    ],
+                    [
+                        "Mn",
+                        "LMM"
+                    ],
+                    [
+                        "Mo",
+                        "3d"
+                    ],
+                    [
+                        "Mo",
+                        "3d3/2"
+                    ],
+                    [
+                        "Mo",
+                        "3d5/2"
+                    ],
+                    [
+                        "Mo",
+                        "3p"
+                    ],
+                    [
+                        "Mo",
+                        "3p1/2"
+                    ],
+                    [
+                        "Mo",
+                        "3p3/2"
+                    ],
+                    [
+                        "Mo",
+                        "3s"
+                    ],
+                    [
+                        "Mo",
+                        "4d"
+                    ],
+                    [
+                        "Mo",
+                        "4d3/2"
+                    ],
+                    [
+                        "Mo",
+                        "4d5/2"
+                    ],
+                    [
+                        "Mo",
+                        "4p"
+                    ],
+                    [
+                        "Mo",
+                        "4p1/2"
+                    ],
+                    [
+                        "Mo",
+                        "4p3/2"
+                    ],
+                    [
+                        "Mo",
+                        "4s"
+                    ],
+                    [
+                        "Mo",
+                        "MNV"
+                    ],
+                    [
+                        "N",
+                        "1s"
+                    ],
+                    [
+                        "N",
+                        "2p"
+                    ],
+                    [
+                        "N",
+                        "2p1/2"
+                    ],
+                    [
+                        "N",
+                        "2p3/2"
+                    ],
+                    [
+                        "N",
+                        "KLL"
+                    ],
+                    [
+                        "Na",
+                        "1s"
+                    ],
+                    [
+                        "Na",
+                        "2p"
+                    ],
+                    [
+                        "Na",
+                        "2p1/2"
+                    ],
+                    [
+                        "Na",
+                        "2p3/2"
+                    ],
+                    [
+                        "Na",
+                        "2s"
+                    ],
+                    [
+                        "Na",
+                        "3s"
+                    ],
+                    [
+                        "Na",
+                        "KLL"
+                    ],
+                    [
+                        "Nb",
+                        "3d"
+                    ],
+                    [
+                        "Nb",
+                        "3d3/2"
+                    ],
+                    [
+                        "Nb",
+                        "3d5/2"
+                    ],
+                    [
+                        "Nb",
+                        "3p"
+                    ],
+                    [
+                        "Nb",
+                        "3p1/2"
+                    ],
+                    [
+                        "Nb",
+                        "3p3/2"
+                    ],
+                    [
+                        "Nb",
+                        "3s"
+                    ],
+                    [
+                        "Nb",
+                        "4d"
+                    ],
+                    [
+                        "Nb",
+                        "4d3/2"
+                    ],
+                    [
+                        "Nb",
+                        "4d5/2"
+                    ],
+                    [
+                        "Nb",
+                        "4p"
+                    ],
+                    [
+                        "Nb",
+                        "4p1/2"
+                    ],
+                    [
+                        "Nb",
+                        "4p3/2"
+                    ],
+                    [
+                        "Nb",
+                        "4s"
+                    ],
+                    [
+                        "Nb",
+                        "MNV"
+                    ],
+                    [
+                        "Nd",
+                        "3d"
+                    ],
+                    [
+                        "Nd",
+                        "3d3/2"
+                    ],
+                    [
+                        "Nd",
+                        "3d5/2"
+                    ],
+                    [
+                        "Nd",
+                        "4d"
+                    ],
+                    [
+                        "Nd",
+                        "4d3/2"
+                    ],
+                    [
+                        "Nd",
+                        "4d5/2"
+                    ],
+                    [
+                        "Nd",
+                        "4f"
+                    ],
+                    [
+                        "Nd",
+                        "4f5/2"
+                    ],
+                    [
+                        "Nd",
+                        "4f7/2"
+                    ],
+                    [
+                        "Nd",
+                        "4p"
+                    ],
+                    [
+                        "Nd",
+                        "4p1/2"
+                    ],
+                    [
+                        "Nd",
+                        "4p3/2"
+                    ],
+                    [
+                        "Nd",
+                        "4s"
+                    ],
+                    [
+                        "Nd",
+                        "5p"
+                    ],
+                    [
+                        "Nd",
+                        "5p1/2"
+                    ],
+                    [
+                        "Nd",
+                        "5p3/2"
+                    ],
+                    [
+                        "Nd",
+                        "5s"
+                    ],
+                    [
+                        "Nd",
+                        "MNN"
+                    ],
+                    [
+                        "Ne",
+                        "1s"
+                    ],
+                    [
+                        "Ne",
+                        "2p"
+                    ],
+                    [
+                        "Ne",
+                        "2p1/2"
+                    ],
+                    [
+                        "Ne",
+                        "2p3/2"
+                    ],
+                    [
+                        "Ne",
+                        "2s"
+                    ],
+                    [
+                        "Ni",
+                        "2p"
+                    ],
+                    [
+                        "Ni",
+                        "2p1/2"
+                    ],
+                    [
+                        "Ni",
+                        "2p3/2"
+                    ],
+                    [
+                        "Ni",
+                        "2s"
+                    ],
+                    [
+                        "Ni",
+                        "3d"
+                    ],
+                    [
+                        "Ni",
+                        "3d3/2"
+                    ],
+                    [
+                        "Ni",
+                        "3d5/2"
+                    ],
+                    [
+                        "Ni",
+                        "3p"
+                    ],
+                    [
+                        "Ni",
+                        "3p1/2"
+                    ],
+                    [
+                        "Ni",
+                        "3p3/2"
+                    ],
+                    [
+                        "Ni",
+                        "3s"
+                    ],
+                    [
+                        "Ni",
+                        "LMM"
+                    ],
+                    [
+                        "O",
+                        "1s"
+                    ],
+                    [
+                        "O",
+                        "2p"
+                    ],
+                    [
+                        "O",
+                        "2p1/2"
+                    ],
+                    [
+                        "O",
+                        "2p3/2"
+                    ],
+                    [
+                        "O",
+                        "2s"
+                    ],
+                    [
+                        "O",
+                        "KLL"
+                    ],
+                    [
+                        "Os",
+                        "4d"
+                    ],
+                    [
+                        "Os",
+                        "4d3/2"
+                    ],
+                    [
+                        "Os",
+                        "4d5/2"
+                    ],
+                    [
+                        "Os",
+                        "4f"
+                    ],
+                    [
+                        "Os",
+                        "4f5/2"
+                    ],
+                    [
+                        "Os",
+                        "4f7/2"
+                    ],
+                    [
+                        "Os",
+                        "4p"
+                    ],
+                    [
+                        "Os",
+                        "4p1/2"
+                    ],
+                    [
+                        "Os",
+                        "4p3/2"
+                    ],
+                    [
+                        "Os",
+                        "4s"
+                    ],
+                    [
+                        "Os",
+                        "5p"
+                    ],
+                    [
+                        "Os",
+                        "5p1/2"
+                    ],
+                    [
+                        "Os",
+                        "5p3/2"
+                    ],
+                    [
+                        "Os",
+                        "5s"
+                    ],
+                    [
+                        "Os",
+                        "NOO"
+                    ],
+                    [
+                        "P",
+                        "2p"
+                    ],
+                    [
+                        "P",
+                        "2p1/2"
+                    ],
+                    [
+                        "P",
+                        "2p3/2"
+                    ],
+                    [
+                        "P",
+                        "2s"
+                    ],
+                    [
+                        "P",
+                        "3p"
+                    ],
+                    [
+                        "P",
+                        "3p1/2"
+                    ],
+                    [
+                        "P",
+                        "3p3/2"
+                    ],
+                    [
+                        "P",
+                        "3s"
+                    ],
+                    [
+                        "P",
+                        "KLL"
+                    ],
+                    [
+                        "P",
+                        "LMM"
+                    ],
+                    [
+                        "Pb",
+                        "4d"
+                    ],
+                    [
+                        "Pb",
+                        "4d3/2"
+                    ],
+                    [
+                        "Pb",
+                        "4d5/2"
+                    ],
+                    [
+                        "Pb",
+                        "4f"
+                    ],
+                    [
+                        "Pb",
+                        "4f5/2"
+                    ],
+                    [
+                        "Pb",
+                        "4f7/2"
+                    ],
+                    [
+                        "Pb",
+                        "4p"
+                    ],
+                    [
+                        "Pb",
+                        "4p1/2"
+                    ],
+                    [
+                        "Pb",
+                        "4p3/2"
+                    ],
+                    [
+                        "Pb",
+                        "4s"
+                    ],
+                    [
+                        "Pb",
+                        "5d"
+                    ],
+                    [
+                        "Pb",
+                        "5d3/2"
+                    ],
+                    [
+                        "Pb",
+                        "5d5/2"
+                    ],
+                    [
+                        "Pb",
+                        "5p"
+                    ],
+                    [
+                        "Pb",
+                        "5p1/2"
+                    ],
+                    [
+                        "Pb",
+                        "5p3/2"
+                    ],
+                    [
+                        "Pb",
+                        "5s"
+                    ],
+                    [
+                        "Pb",
+                        "6p"
+                    ],
+                    [
+                        "Pb",
+                        "6p1/2"
+                    ],
+                    [
+                        "Pb",
+                        "6p3/2"
+                    ],
+                    [
+                        "Pb",
+                        "6s"
+                    ],
+                    [
+                        "Pd",
+                        "3d"
+                    ],
+                    [
+                        "Pd",
+                        "3d3/2"
+                    ],
+                    [
+                        "Pd",
+                        "3d5/2"
+                    ],
+                    [
+                        "Pd",
+                        "3p"
+                    ],
+                    [
+                        "Pd",
+                        "3p1/2"
+                    ],
+                    [
+                        "Pd",
+                        "3p3/2"
+                    ],
+                    [
+                        "Pd",
+                        "3s"
+                    ],
+                    [
+                        "Pd",
+                        "4d"
+                    ],
+                    [
+                        "Pd",
+                        "4d3/2"
+                    ],
+                    [
+                        "Pd",
+                        "4d5/2"
+                    ],
+                    [
+                        "Pd",
+                        "4p"
+                    ],
+                    [
+                        "Pd",
+                        "4p1/2"
+                    ],
+                    [
+                        "Pd",
+                        "4p3/2"
+                    ],
+                    [
+                        "Pd",
+                        "4s"
+                    ],
+                    [
+                        "Pd",
+                        "MNN"
+                    ],
+                    [
+                        "Pm",
+                        "3d"
+                    ],
+                    [
+                        "Pm",
+                        "3d3/2"
+                    ],
+                    [
+                        "Pm",
+                        "3d5/2"
+                    ],
+                    [
+                        "Pm",
+                        "4d"
+                    ],
+                    [
+                        "Pm",
+                        "4d3/2"
+                    ],
+                    [
+                        "Pm",
+                        "4d5/2"
+                    ],
+                    [
+                        "Pm",
+                        "4f"
+                    ],
+                    [
+                        "Pm",
+                        "4f5/2"
+                    ],
+                    [
+                        "Pm",
+                        "4f7/2"
+                    ],
+                    [
+                        "Pm",
+                        "4p"
+                    ],
+                    [
+                        "Pm",
+                        "4p1/2"
+                    ],
+                    [
+                        "Pm",
+                        "4p3/2"
+                    ],
+                    [
+                        "Pm",
+                        "4s"
+                    ],
+                    [
+                        "Pm",
+                        "5p"
+                    ],
+                    [
+                        "Pm",
+                        "5p1/2"
+                    ],
+                    [
+                        "Pm",
+                        "5p3/2"
+                    ],
+                    [
+                        "Pm",
+                        "5s"
+                    ],
+                    [
+                        "Po",
+                        "4d"
+                    ],
+                    [
+                        "Po",
+                        "4d3/2"
+                    ],
+                    [
+                        "Po",
+                        "4d5/2"
+                    ],
+                    [
+                        "Po",
+                        "4f"
+                    ],
+                    [
+                        "Po",
+                        "4f5/2"
+                    ],
+                    [
+                        "Po",
+                        "4f7/2"
+                    ],
+                    [
+                        "Po",
+                        "4p"
+                    ],
+                    [
+                        "Po",
+                        "4p1/2"
+                    ],
+                    [
+                        "Po",
+                        "4p3/2"
+                    ],
+                    [
+                        "Po",
+                        "4s"
+                    ],
+                    [
+                        "Po",
+                        "5d"
+                    ],
+                    [
+                        "Po",
+                        "5d3/2"
+                    ],
+                    [
+                        "Po",
+                        "5d5/2"
+                    ],
+                    [
+                        "Po",
+                        "5p"
+                    ],
+                    [
+                        "Po",
+                        "5p1/2"
+                    ],
+                    [
+                        "Po",
+                        "5p3/2"
+                    ],
+                    [
+                        "Po",
+                        "5s"
+                    ],
+                    [
+                        "Po",
+                        "6p"
+                    ],
+                    [
+                        "Po",
+                        "6p1/2"
+                    ],
+                    [
+                        "Po",
+                        "6p3/2"
+                    ],
+                    [
+                        "Po",
+                        "6s"
+                    ],
+                    [
+                        "Pr",
+                        "3d"
+                    ],
+                    [
+                        "Pr",
+                        "3d3/2"
+                    ],
+                    [
+                        "Pr",
+                        "3d5/2"
+                    ],
+                    [
+                        "Pr",
+                        "3p"
+                    ],
+                    [
+                        "Pr",
+                        "3p3/2"
+                    ],
+                    [
+                        "Pr",
+                        "4d"
+                    ],
+                    [
+                        "Pr",
+                        "4d3/2"
+                    ],
+                    [
+                        "Pr",
+                        "4d5/2"
+                    ],
+                    [
+                        "Pr",
+                        "4f"
+                    ],
+                    [
+                        "Pr",
+                        "4f5/2"
+                    ],
+                    [
+                        "Pr",
+                        "4f7/2"
+                    ],
+                    [
+                        "Pr",
+                        "4p"
+                    ],
+                    [
+                        "Pr",
+                        "4p1/2"
+                    ],
+                    [
+                        "Pr",
+                        "4p3/2"
+                    ],
+                    [
+                        "Pr",
+                        "4s"
+                    ],
+                    [
+                        "Pr",
+                        "5p"
+                    ],
+                    [
+                        "Pr",
+                        "5p1/2"
+                    ],
+                    [
+                        "Pr",
+                        "5p3/2"
+                    ],
+                    [
+                        "Pr",
+                        "5s"
+                    ],
+                    [
+                        "Pr",
+                        "MNN"
+                    ],
+                    [
+                        "Pt",
+                        "4d"
+                    ],
+                    [
+                        "Pt",
+                        "4d3/2"
+                    ],
+                    [
+                        "Pt",
+                        "4d5/2"
+                    ],
+                    [
+                        "Pt",
+                        "4f"
+                    ],
+                    [
+                        "Pt",
+                        "4f5/2"
+                    ],
+                    [
+                        "Pt",
+                        "4f7/2"
+                    ],
+                    [
+                        "Pt",
+                        "4p"
+                    ],
+                    [
+                        "Pt",
+                        "4p1/2"
+                    ],
+                    [
+                        "Pt",
+                        "4p3/2"
+                    ],
+                    [
+                        "Pt",
+                        "4s"
+                    ],
+                    [
+                        "Pt",
+                        "5d"
+                    ],
+                    [
+                        "Pt",
+                        "5d3/2"
+                    ],
+                    [
+                        "Pt",
+                        "5d5/2"
+                    ],
+                    [
+                        "Pt",
+                        "5p"
+                    ],
+                    [
+                        "Pt",
+                        "5p1/2"
+                    ],
+                    [
+                        "Pt",
+                        "5p3/2"
+                    ],
+                    [
+                        "Pt",
+                        "5s"
+                    ],
+                    [
+                        "Pt",
+                        "MNN"
+                    ],
+                    [
+                        "Ra",
+                        "4d"
+                    ],
+                    [
+                        "Ra",
+                        "4d3/2"
+                    ],
+                    [
+                        "Ra",
+                        "4d5/2"
+                    ],
+                    [
+                        "Ra",
+                        "4f"
+                    ],
+                    [
+                        "Ra",
+                        "4f5/2"
+                    ],
+                    [
+                        "Ra",
+                        "4f7/2"
+                    ],
+                    [
+                        "Ra",
+                        "4p"
+                    ],
+                    [
+                        "Ra",
+                        "4p1/2"
+                    ],
+                    [
+                        "Ra",
+                        "4p3/2"
+                    ],
+                    [
+                        "Ra",
+                        "4s"
+                    ],
+                    [
+                        "Ra",
+                        "5d"
+                    ],
+                    [
+                        "Ra",
+                        "5d3/2"
+                    ],
+                    [
+                        "Ra",
+                        "5d5/2"
+                    ],
+                    [
+                        "Ra",
+                        "5p"
+                    ],
+                    [
+                        "Ra",
+                        "5p1/2"
+                    ],
+                    [
+                        "Ra",
+                        "5p3/2"
+                    ],
+                    [
+                        "Ra",
+                        "5s"
+                    ],
+                    [
+                        "Ra",
+                        "6p"
+                    ],
+                    [
+                        "Ra",
+                        "6p1/2"
+                    ],
+                    [
+                        "Ra",
+                        "6p3/2"
+                    ],
+                    [
+                        "Ra",
+                        "6s"
+                    ],
+                    [
+                        "Rb",
+                        "3d"
+                    ],
+                    [
+                        "Rb",
+                        "3d3/2"
+                    ],
+                    [
+                        "Rb",
+                        "3d5/2"
+                    ],
+                    [
+                        "Rb",
+                        "3p"
+                    ],
+                    [
+                        "Rb",
+                        "3p1/2"
+                    ],
+                    [
+                        "Rb",
+                        "3p3/2"
+                    ],
+                    [
+                        "Rb",
+                        "3s"
+                    ],
+                    [
+                        "Rb",
+                        "4p"
+                    ],
+                    [
+                        "Rb",
+                        "4p1/2"
+                    ],
+                    [
+                        "Rb",
+                        "4p3/2"
+                    ],
+                    [
+                        "Rb",
+                        "4s"
+                    ],
+                    [
+                        "Rb",
+                        "LMM"
+                    ],
+                    [
+                        "Re",
+                        "4d"
+                    ],
+                    [
+                        "Re",
+                        "4d3/2"
+                    ],
+                    [
+                        "Re",
+                        "4d5/2"
+                    ],
+                    [
+                        "Re",
+                        "4f"
+                    ],
+                    [
+                        "Re",
+                        "4f5/2"
+                    ],
+                    [
+                        "Re",
+                        "4f7/2"
+                    ],
+                    [
+                        "Re",
+                        "4p"
+                    ],
+                    [
+                        "Re",
+                        "4p1/2"
+                    ],
+                    [
+                        "Re",
+                        "4p3/2"
+                    ],
+                    [
+                        "Re",
+                        "4s"
+                    ],
+                    [
+                        "Re",
+                        "5d"
+                    ],
+                    [
+                        "Re",
+                        "5d3/2"
+                    ],
+                    [
+                        "Re",
+                        "5d5/2"
+                    ],
+                    [
+                        "Re",
+                        "5p"
+                    ],
+                    [
+                        "Re",
+                        "5p1/2"
+                    ],
+                    [
+                        "Re",
+                        "5p3/2"
+                    ],
+                    [
+                        "Re",
+                        "5s"
+                    ],
+                    [
+                        "Re",
+                        "MVV"
+                    ],
+                    [
+                        "Rh",
+                        "3d"
+                    ],
+                    [
+                        "Rh",
+                        "3d3/2"
+                    ],
+                    [
+                        "Rh",
+                        "3d5/2"
+                    ],
+                    [
+                        "Rh",
+                        "3p"
+                    ],
+                    [
+                        "Rh",
+                        "3p1/2"
+                    ],
+                    [
+                        "Rh",
+                        "3p3/2"
+                    ],
+                    [
+                        "Rh",
+                        "3s"
+                    ],
+                    [
+                        "Rh",
+                        "4d"
+                    ],
+                    [
+                        "Rh",
+                        "4d3/2"
+                    ],
+                    [
+                        "Rh",
+                        "4d5/2"
+                    ],
+                    [
+                        "Rh",
+                        "4p"
+                    ],
+                    [
+                        "Rh",
+                        "4p1/2"
+                    ],
+                    [
+                        "Rh",
+                        "4p3/2"
+                    ],
+                    [
+                        "Rh",
+                        "4s"
+                    ],
+                    [
+                        "Rh",
+                        "MNV"
+                    ],
+                    [
+                        "Rn",
+                        "4d"
+                    ],
+                    [
+                        "Rn",
+                        "4d3/2"
+                    ],
+                    [
+                        "Rn",
+                        "4d5/2"
+                    ],
+                    [
+                        "Rn",
+                        "4f"
+                    ],
+                    [
+                        "Rn",
+                        "4f5/2"
+                    ],
+                    [
+                        "Rn",
+                        "4f7/2"
+                    ],
+                    [
+                        "Rn",
+                        "4p"
+                    ],
+                    [
+                        "Rn",
+                        "4p1/2"
+                    ],
+                    [
+                        "Rn",
+                        "4p3/2"
+                    ],
+                    [
+                        "Rn",
+                        "4s"
+                    ],
+                    [
+                        "Rn",
+                        "5d"
+                    ],
+                    [
+                        "Rn",
+                        "5d3/2"
+                    ],
+                    [
+                        "Rn",
+                        "5d5/2"
+                    ],
+                    [
+                        "Rn",
+                        "5p"
+                    ],
+                    [
+                        "Rn",
+                        "5p1/2"
+                    ],
+                    [
+                        "Rn",
+                        "5p3/2"
+                    ],
+                    [
+                        "Rn",
+                        "5s"
+                    ],
+                    [
+                        "Rn",
+                        "6p"
+                    ],
+                    [
+                        "Rn",
+                        "6p1/2"
+                    ],
+                    [
+                        "Rn",
+                        "6p3/2"
+                    ],
+                    [
+                        "Rn",
+                        "6s"
+                    ],
+                    [
+                        "Ru",
+                        "3d"
+                    ],
+                    [
+                        "Ru",
+                        "3d3/2"
+                    ],
+                    [
+                        "Ru",
+                        "3d5/2"
+                    ],
+                    [
+                        "Ru",
+                        "3p"
+                    ],
+                    [
+                        "Ru",
+                        "3p1/2"
+                    ],
+                    [
+                        "Ru",
+                        "3p3/2"
+                    ],
+                    [
+                        "Ru",
+                        "3s"
+                    ],
+                    [
+                        "Ru",
+                        "4d"
+                    ],
+                    [
+                        "Ru",
+                        "4d3/2"
+                    ],
+                    [
+                        "Ru",
+                        "4d5/2"
+                    ],
+                    [
+                        "Ru",
+                        "4p"
+                    ],
+                    [
+                        "Ru",
+                        "4p1/2"
+                    ],
+                    [
+                        "Ru",
+                        "4p3/2"
+                    ],
+                    [
+                        "Ru",
+                        "4s"
+                    ],
+                    [
+                        "Ru",
+                        "MNN"
+                    ],
+                    [
+                        "S",
+                        "2p"
+                    ],
+                    [
+                        "S",
+                        "2p1/2"
+                    ],
+                    [
+                        "S",
+                        "2p3/2"
+                    ],
+                    [
+                        "S",
+                        "2s"
+                    ],
+                    [
+                        "S",
+                        "3p"
+                    ],
+                    [
+                        "S",
+                        "3p1/2"
+                    ],
+                    [
+                        "S",
+                        "3p3/2"
+                    ],
+                    [
+                        "S",
+                        "3s"
+                    ],
+                    [
+                        "S",
+                        "LMM"
+                    ],
+                    [
+                        "Sb",
+                        "3d"
+                    ],
+                    [
+                        "Sb",
+                        "3d3/2"
+                    ],
+                    [
+                        "Sb",
+                        "3d5/2"
+                    ],
+                    [
+                        "Sb",
+                        "3p"
+                    ],
+                    [
+                        "Sb",
+                        "3p1/2"
+                    ],
+                    [
+                        "Sb",
+                        "3p3/2"
+                    ],
+                    [
+                        "Sb",
+                        "3s"
+                    ],
+                    [
+                        "Sb",
+                        "4d"
+                    ],
+                    [
+                        "Sb",
+                        "4d3/2"
+                    ],
+                    [
+                        "Sb",
+                        "4d5/2"
+                    ],
+                    [
+                        "Sb",
+                        "4p"
+                    ],
+                    [
+                        "Sb",
+                        "4p1/2"
+                    ],
+                    [
+                        "Sb",
+                        "4p3/2"
+                    ],
+                    [
+                        "Sb",
+                        "4s"
+                    ],
+                    [
+                        "Sb",
+                        "5p"
+                    ],
+                    [
+                        "Sb",
+                        "5p1/2"
+                    ],
+                    [
+                        "Sb",
+                        "5p3/2"
+                    ],
+                    [
+                        "Sb",
+                        "5s"
+                    ],
+                    [
+                        "Sb",
+                        "MNN"
+                    ],
+                    [
+                        "Sc",
+                        "2p"
+                    ],
+                    [
+                        "Sc",
+                        "2p1/2"
+                    ],
+                    [
+                        "Sc",
+                        "2p3/2"
+                    ],
+                    [
+                        "Sc",
+                        "2s"
+                    ],
+                    [
+                        "Sc",
+                        "3d"
+                    ],
+                    [
+                        "Sc",
+                        "3d3/2"
+                    ],
+                    [
+                        "Sc",
+                        "3d5/2"
+                    ],
+                    [
+                        "Sc",
+                        "3p"
+                    ],
+                    [
+                        "Sc",
+                        "3p1/2"
+                    ],
+                    [
+                        "Sc",
+                        "3p3/2"
+                    ],
+                    [
+                        "Sc",
+                        "3s"
+                    ],
+                    [
+                        "Sc",
+                        "LMM"
+                    ],
+                    [
+                        "Se",
+                        "3d"
+                    ],
+                    [
+                        "Se",
+                        "3d3/2"
+                    ],
+                    [
+                        "Se",
+                        "3d5/2"
+                    ],
+                    [
+                        "Se",
+                        "3p"
+                    ],
+                    [
+                        "Se",
+                        "3p1/2"
+                    ],
+                    [
+                        "Se",
+                        "3p3/2"
+                    ],
+                    [
+                        "Se",
+                        "3s"
+                    ],
+                    [
+                        "Se",
+                        "4p"
+                    ],
+                    [
+                        "Se",
+                        "4p1/2"
+                    ],
+                    [
+                        "Se",
+                        "4p3/2"
+                    ],
+                    [
+                        "Se",
+                        "LMM"
+                    ],
+                    [
+                        "Si",
+                        "2p"
+                    ],
+                    [
+                        "Si",
+                        "2p1/2"
+                    ],
+                    [
+                        "Si",
+                        "2p3/2"
+                    ],
+                    [
+                        "Si",
+                        "2s"
+                    ],
+                    [
+                        "Si",
+                        "3p"
+                    ],
+                    [
+                        "Si",
+                        "3p1/2"
+                    ],
+                    [
+                        "Si",
+                        "3p3/2"
+                    ],
+                    [
+                        "Si",
+                        "3s"
+                    ],
+                    [
+                        "Si",
+                        "KLL"
+                    ],
+                    [
+                        "Si",
+                        "LMM"
+                    ],
+                    [
+                        "Sm",
+                        "3d"
+                    ],
+                    [
+                        "Sm",
+                        "3d3/2"
+                    ],
+                    [
+                        "Sm",
+                        "3d5/2"
+                    ],
+                    [
+                        "Sm",
+                        "4d"
+                    ],
+                    [
+                        "Sm",
+                        "4d3/2"
+                    ],
+                    [
+                        "Sm",
+                        "4d5/2"
+                    ],
+                    [
+                        "Sm",
+                        "4f"
+                    ],
+                    [
+                        "Sm",
+                        "4f5/2"
+                    ],
+                    [
+                        "Sm",
+                        "4f7/2"
+                    ],
+                    [
+                        "Sm",
+                        "4p"
+                    ],
+                    [
+                        "Sm",
+                        "4p1/2"
+                    ],
+                    [
+                        "Sm",
+                        "4p3/2"
+                    ],
+                    [
+                        "Sm",
+                        "4s"
+                    ],
+                    [
+                        "Sm",
+                        "5p"
+                    ],
+                    [
+                        "Sm",
+                        "5p1/2"
+                    ],
+                    [
+                        "Sm",
+                        "5p3/2"
+                    ],
+                    [
+                        "Sm",
+                        "5s"
+                    ],
+                    [
+                        "Sm",
+                        "MNN"
+                    ],
+                    [
+                        "Sn",
+                        "3d"
+                    ],
+                    [
+                        "Sn",
+                        "3d3/2"
+                    ],
+                    [
+                        "Sn",
+                        "3d5/2"
+                    ],
+                    [
+                        "Sn",
+                        "3p"
+                    ],
+                    [
+                        "Sn",
+                        "3p1/2"
+                    ],
+                    [
+                        "Sn",
+                        "3p3/2"
+                    ],
+                    [
+                        "Sn",
+                        "3s"
+                    ],
+                    [
+                        "Sn",
+                        "4d"
+                    ],
+                    [
+                        "Sn",
+                        "4d3/2"
+                    ],
+                    [
+                        "Sn",
+                        "4d5/2"
+                    ],
+                    [
+                        "Sn",
+                        "4p"
+                    ],
+                    [
+                        "Sn",
+                        "4p1/2"
+                    ],
+                    [
+                        "Sn",
+                        "4p3/2"
+                    ],
+                    [
+                        "Sn",
+                        "4s"
+                    ],
+                    [
+                        "Sn",
+                        "5p"
+                    ],
+                    [
+                        "Sn",
+                        "5p1/2"
+                    ],
+                    [
+                        "Sn",
+                        "5p3/2"
+                    ],
+                    [
+                        "Sn",
+                        "5s"
+                    ],
+                    [
+                        "Sn",
+                        "MNN"
+                    ],
+                    [
+                        "Sr",
+                        "3d"
+                    ],
+                    [
+                        "Sr",
+                        "3d3/2"
+                    ],
+                    [
+                        "Sr",
+                        "3d5/2"
+                    ],
+                    [
+                        "Sr",
+                        "3p"
+                    ],
+                    [
+                        "Sr",
+                        "3p1/2"
+                    ],
+                    [
+                        "Sr",
+                        "3p3/2"
+                    ],
+                    [
+                        "Sr",
+                        "3s"
+                    ],
+                    [
+                        "Sr",
+                        "4p"
+                    ],
+                    [
+                        "Sr",
+                        "4p1/2"
+                    ],
+                    [
+                        "Sr",
+                        "4p3/2"
+                    ],
+                    [
+                        "Sr",
+                        "4s"
+                    ],
+                    [
+                        "Sr",
+                        "LMM"
+                    ],
+                    [
+                        "Ta",
+                        "4d"
+                    ],
+                    [
+                        "Ta",
+                        "4d3/2"
+                    ],
+                    [
+                        "Ta",
+                        "4d5/2"
+                    ],
+                    [
+                        "Ta",
+                        "4f"
+                    ],
+                    [
+                        "Ta",
+                        "4f5/2"
+                    ],
+                    [
+                        "Ta",
+                        "4f7/2"
+                    ],
+                    [
+                        "Ta",
+                        "4p"
+                    ],
+                    [
+                        "Ta",
+                        "4p1/2"
+                    ],
+                    [
+                        "Ta",
+                        "4p3/2"
+                    ],
+                    [
+                        "Ta",
+                        "4s"
+                    ],
+                    [
+                        "Ta",
+                        "5d"
+                    ],
+                    [
+                        "Ta",
+                        "5d3/2"
+                    ],
+                    [
+                        "Ta",
+                        "5d5/2"
+                    ],
+                    [
+                        "Ta",
+                        "5p"
+                    ],
+                    [
+                        "Ta",
+                        "5p1/2"
+                    ],
+                    [
+                        "Ta",
+                        "5p3/2"
+                    ],
+                    [
+                        "Ta",
+                        "5s"
+                    ],
+                    [
+                        "Ta",
+                        "MVV"
+                    ],
+                    [
+                        "Tb",
+                        "3d"
+                    ],
+                    [
+                        "Tb",
+                        "3d3/2"
+                    ],
+                    [
+                        "Tb",
+                        "3d5/2"
+                    ],
+                    [
+                        "Tb",
+                        "4d"
+                    ],
+                    [
+                        "Tb",
+                        "4d3/2"
+                    ],
+                    [
+                        "Tb",
+                        "4d5/2"
+                    ],
+                    [
+                        "Tb",
+                        "4f"
+                    ],
+                    [
+                        "Tb",
+                        "4f5/2"
+                    ],
+                    [
+                        "Tb",
+                        "4f7/2"
+                    ],
+                    [
+                        "Tb",
+                        "4p"
+                    ],
+                    [
+                        "Tb",
+                        "4p1/2"
+                    ],
+                    [
+                        "Tb",
+                        "4p3/2"
+                    ],
+                    [
+                        "Tb",
+                        "4s"
+                    ],
+                    [
+                        "Tb",
+                        "5p"
+                    ],
+                    [
+                        "Tb",
+                        "5p1/2"
+                    ],
+                    [
+                        "Tb",
+                        "5p3/2"
+                    ],
+                    [
+                        "Tb",
+                        "5s"
+                    ],
+                    [
+                        "Tb",
+                        "MNN"
+                    ],
+                    [
+                        "Tc",
+                        "3d"
+                    ],
+                    [
+                        "Tc",
+                        "3d3/2"
+                    ],
+                    [
+                        "Tc",
+                        "3d5/2"
+                    ],
+                    [
+                        "Tc",
+                        "3p"
+                    ],
+                    [
+                        "Tc",
+                        "3p1/2"
+                    ],
+                    [
+                        "Tc",
+                        "3p3/2"
+                    ],
+                    [
+                        "Tc",
+                        "3s"
+                    ],
+                    [
+                        "Tc",
+                        "4d"
+                    ],
+                    [
+                        "Tc",
+                        "4d3/2"
+                    ],
+                    [
+                        "Tc",
+                        "4d5/2"
+                    ],
+                    [
+                        "Tc",
+                        "4p"
+                    ],
+                    [
+                        "Tc",
+                        "4p1/2"
+                    ],
+                    [
+                        "Tc",
+                        "4p3/2"
+                    ],
+                    [
+                        "Tc",
+                        "4s"
+                    ],
+                    [
+                        "Te",
+                        "3d"
+                    ],
+                    [
+                        "Te",
+                        "3d3/2"
+                    ],
+                    [
+                        "Te",
+                        "3d5/2"
+                    ],
+                    [
+                        "Te",
+                        "3p"
+                    ],
+                    [
+                        "Te",
+                        "3p1/2"
+                    ],
+                    [
+                        "Te",
+                        "3p3/2"
+                    ],
+                    [
+                        "Te",
+                        "3s"
+                    ],
+                    [
+                        "Te",
+                        "4d"
+                    ],
+                    [
+                        "Te",
+                        "4d3/2"
+                    ],
+                    [
+                        "Te",
+                        "4d5/2"
+                    ],
+                    [
+                        "Te",
+                        "4p"
+                    ],
+                    [
+                        "Te",
+                        "4p1/2"
+                    ],
+                    [
+                        "Te",
+                        "4p3/2"
+                    ],
+                    [
+                        "Te",
+                        "4s"
+                    ],
+                    [
+                        "Te",
+                        "5p"
+                    ],
+                    [
+                        "Te",
+                        "5p1/2"
+                    ],
+                    [
+                        "Te",
+                        "5p3/2"
+                    ],
+                    [
+                        "Te",
+                        "5s"
+                    ],
+                    [
+                        "Te",
+                        "MNN"
+                    ],
+                    [
+                        "Th",
+                        "4d"
+                    ],
+                    [
+                        "Th",
+                        "4d3/2"
+                    ],
+                    [
+                        "Th",
+                        "4d5/2"
+                    ],
+                    [
+                        "Th",
+                        "4f"
+                    ],
+                    [
+                        "Th",
+                        "4f5/2"
+                    ],
+                    [
+                        "Th",
+                        "4f7/2"
+                    ],
+                    [
+                        "Th",
+                        "4p"
+                    ],
+                    [
+                        "Th",
+                        "4p1/2"
+                    ],
+                    [
+                        "Th",
+                        "4p3/2"
+                    ],
+                    [
+                        "Th",
+                        "5d"
+                    ],
+                    [
+                        "Th",
+                        "5d3/2"
+                    ],
+                    [
+                        "Th",
+                        "5d5/2"
+                    ],
+                    [
+                        "Th",
+                        "5p"
+                    ],
+                    [
+                        "Th",
+                        "5p1/2"
+                    ],
+                    [
+                        "Th",
+                        "5p3/2"
+                    ],
+                    [
+                        "Th",
+                        "5s"
+                    ],
+                    [
+                        "Th",
+                        "6p"
+                    ],
+                    [
+                        "Th",
+                        "6p1/2"
+                    ],
+                    [
+                        "Th",
+                        "6p3/2"
+                    ],
+                    [
+                        "Th",
+                        "6s"
+                    ],
+                    [
+                        "Ti",
+                        "2p"
+                    ],
+                    [
+                        "Ti",
+                        "2p1/2"
+                    ],
+                    [
+                        "Ti",
+                        "2p3/2"
+                    ],
+                    [
+                        "Ti",
+                        "2s"
+                    ],
+                    [
+                        "Ti",
+                        "3d"
+                    ],
+                    [
+                        "Ti",
+                        "3d3/2"
+                    ],
+                    [
+                        "Ti",
+                        "3d5/2"
+                    ],
+                    [
+                        "Ti",
+                        "3p"
+                    ],
+                    [
+                        "Ti",
+                        "3p1/2"
+                    ],
+                    [
+                        "Ti",
+                        "3p3/2"
+                    ],
+                    [
+                        "Ti",
+                        "3s"
+                    ],
+                    [
+                        "Ti",
+                        "LMM"
+                    ],
+                    [
+                        "Tl",
+                        "4d"
+                    ],
+                    [
+                        "Tl",
+                        "4d3/2"
+                    ],
+                    [
+                        "Tl",
+                        "4d5/2"
+                    ],
+                    [
+                        "Tl",
+                        "4f"
+                    ],
+                    [
+                        "Tl",
+                        "4f5/2"
+                    ],
+                    [
+                        "Tl",
+                        "4f7/2"
+                    ],
+                    [
+                        "Tl",
+                        "4p"
+                    ],
+                    [
+                        "Tl",
+                        "4p1/2"
+                    ],
+                    [
+                        "Tl",
+                        "4p3/2"
+                    ],
+                    [
+                        "Tl",
+                        "4s"
+                    ],
+                    [
+                        "Tl",
+                        "5d"
+                    ],
+                    [
+                        "Tl",
+                        "5d3/2"
+                    ],
+                    [
+                        "Tl",
+                        "5d5/2"
+                    ],
+                    [
+                        "Tl",
+                        "5p"
+                    ],
+                    [
+                        "Tl",
+                        "5p1/2"
+                    ],
+                    [
+                        "Tl",
+                        "5p3/2"
+                    ],
+                    [
+                        "Tl",
+                        "5s"
+                    ],
+                    [
+                        "Tl",
+                        "NOO"
+                    ],
+                    [
+                        "Tm",
+                        "4d"
+                    ],
+                    [
+                        "Tm",
+                        "4d3/2"
+                    ],
+                    [
+                        "Tm",
+                        "4d5/2"
+                    ],
+                    [
+                        "Tm",
+                        "4f"
+                    ],
+                    [
+                        "Tm",
+                        "4f5/2"
+                    ],
+                    [
+                        "Tm",
+                        "4f7/2"
+                    ],
+                    [
+                        "Tm",
+                        "4p"
+                    ],
+                    [
+                        "Tm",
+                        "4p1/2"
+                    ],
+                    [
+                        "Tm",
+                        "4p3/2"
+                    ],
+                    [
+                        "Tm",
+                        "4s"
+                    ],
+                    [
+                        "Tm",
+                        "5p"
+                    ],
+                    [
+                        "Tm",
+                        "5p1/2"
+                    ],
+                    [
+                        "Tm",
+                        "5p3/2"
+                    ],
+                    [
+                        "Tm",
+                        "5s"
+                    ],
+                    [
+                        "Tm",
+                        "MVV"
+                    ],
+                    [
+                        "U",
+                        "4d"
+                    ],
+                    [
+                        "U",
+                        "4d3/2"
+                    ],
+                    [
+                        "U",
+                        "4d5/2"
+                    ],
+                    [
+                        "U",
+                        "4f"
+                    ],
+                    [
+                        "U",
+                        "4f5/2"
+                    ],
+                    [
+                        "U",
+                        "4f7/2"
+                    ],
+                    [
+                        "U",
+                        "4s"
+                    ],
+                    [
+                        "U",
+                        "5d"
+                    ],
+                    [
+                        "U",
+                        "5d3/2"
+                    ],
+                    [
+                        "U",
+                        "5d5/2"
+                    ],
+                    [
+                        "U",
+                        "6p"
+                    ],
+                    [
+                        "U",
+                        "6p1/2"
+                    ],
+                    [
+                        "U",
+                        "6p3/2"
+                    ],
+                    [
+                        "V",
+                        "2p"
+                    ],
+                    [
+                        "V",
+                        "2p1/2"
+                    ],
+                    [
+                        "V",
+                        "2p3/2"
+                    ],
+                    [
+                        "V",
+                        "2s"
+                    ],
+                    [
+                        "V",
+                        "3d"
+                    ],
+                    [
+                        "V",
+                        "3d3/2"
+                    ],
+                    [
+                        "V",
+                        "3d5/2"
+                    ],
+                    [
+                        "V",
+                        "3p"
+                    ],
+                    [
+                        "V",
+                        "3p1/2"
+                    ],
+                    [
+                        "V",
+                        "3p3/2"
+                    ],
+                    [
+                        "V",
+                        "3s"
+                    ],
+                    [
+                        "V",
+                        "LMM"
+                    ],
+                    [
+                        "W",
+                        "4d"
+                    ],
+                    [
+                        "W",
+                        "4d3/2"
+                    ],
+                    [
+                        "W",
+                        "4d5/2"
+                    ],
+                    [
+                        "W",
+                        "4f"
+                    ],
+                    [
+                        "W",
+                        "4f5/2"
+                    ],
+                    [
+                        "W",
+                        "4f7/2"
+                    ],
+                    [
+                        "W",
+                        "4p"
+                    ],
+                    [
+                        "W",
+                        "4p1/2"
+                    ],
+                    [
+                        "W",
+                        "4p3/2"
+                    ],
+                    [
+                        "W",
+                        "4s"
+                    ],
+                    [
+                        "W",
+                        "5d"
+                    ],
+                    [
+                        "W",
+                        "5d3/2"
+                    ],
+                    [
+                        "W",
+                        "5d5/2"
+                    ],
+                    [
+                        "W",
+                        "5p"
+                    ],
+                    [
+                        "W",
+                        "5p1/2"
+                    ],
+                    [
+                        "W",
+                        "5p3/2"
+                    ],
+                    [
+                        "W",
+                        "5s"
+                    ],
+                    [
+                        "W",
+                        "MVV"
+                    ],
+                    [
+                        "Xe",
+                        "3d"
+                    ],
+                    [
+                        "Xe",
+                        "3d3/2"
+                    ],
+                    [
+                        "Xe",
+                        "3d5/2"
+                    ],
+                    [
+                        "Xe",
+                        "3p"
+                    ],
+                    [
+                        "Xe",
+                        "3p1/2"
+                    ],
+                    [
+                        "Xe",
+                        "3p3/2"
+                    ],
+                    [
+                        "Xe",
+                        "3s"
+                    ],
+                    [
+                        "Xe",
+                        "4d"
+                    ],
+                    [
+                        "Xe",
+                        "4d3/2"
+                    ],
+                    [
+                        "Xe",
+                        "4d5/2"
+                    ],
+                    [
+                        "Xe",
+                        "4p"
+                    ],
+                    [
+                        "Xe",
+                        "4p1/2"
+                    ],
+                    [
+                        "Xe",
+                        "4p3/2"
+                    ],
+                    [
+                        "Xe",
+                        "4s"
+                    ],
+                    [
+                        "Xe",
+                        "5p"
+                    ],
+                    [
+                        "Xe",
+                        "5p1/2"
+                    ],
+                    [
+                        "Xe",
+                        "5p3/2"
+                    ],
+                    [
+                        "Xe",
+                        "5s"
+                    ],
+                    [
+                        "Xe",
+                        "MNN"
+                    ],
+                    [
+                        "Y",
+                        "3d"
+                    ],
+                    [
+                        "Y",
+                        "3d3/2"
+                    ],
+                    [
+                        "Y",
+                        "3d5/2"
+                    ],
+                    [
+                        "Y",
+                        "3p"
+                    ],
+                    [
+                        "Y",
+                        "3p1/2"
+                    ],
+                    [
+                        "Y",
+                        "3p3/2"
+                    ],
+                    [
+                        "Y",
+                        "3s"
+                    ],
+                    [
+                        "Y",
+                        "4d"
+                    ],
+                    [
+                        "Y",
+                        "4d3/2"
+                    ],
+                    [
+                        "Y",
+                        "4d5/2"
+                    ],
+                    [
+                        "Y",
+                        "4p"
+                    ],
+                    [
+                        "Y",
+                        "4p1/2"
+                    ],
+                    [
+                        "Y",
+                        "4p3/2"
+                    ],
+                    [
+                        "Y",
+                        "4s"
+                    ],
+                    [
+                        "Y",
+                        "LMM"
+                    ],
+                    [
+                        "Yb",
+                        "4d"
+                    ],
+                    [
+                        "Yb",
+                        "4d3/2"
+                    ],
+                    [
+                        "Yb",
+                        "4d5/2"
+                    ],
+                    [
+                        "Yb",
+                        "4f"
+                    ],
+                    [
+                        "Yb",
+                        "4f5/2"
+                    ],
+                    [
+                        "Yb",
+                        "4f7/2"
+                    ],
+                    [
+                        "Yb",
+                        "4p"
+                    ],
+                    [
+                        "Yb",
+                        "4p1/2"
+                    ],
+                    [
+                        "Yb",
+                        "4p3/2"
+                    ],
+                    [
+                        "Yb",
+                        "4s"
+                    ],
+                    [
+                        "Yb",
+                        "5p"
+                    ],
+                    [
+                        "Yb",
+                        "5p1/2"
+                    ],
+                    [
+                        "Yb",
+                        "5p3/2"
+                    ],
+                    [
+                        "Yb",
+                        "5s"
+                    ],
+                    [
+                        "Yb",
+                        "MVV"
+                    ],
+                    [
+                        "Zn",
+                        "2p"
+                    ],
+                    [
+                        "Zn",
+                        "2p1/2"
+                    ],
+                    [
+                        "Zn",
+                        "2p3/2"
+                    ],
+                    [
+                        "Zn",
+                        "2s"
+                    ],
+                    [
+                        "Zn",
+                        "3d"
+                    ],
+                    [
+                        "Zn",
+                        "3d3/2"
+                    ],
+                    [
+                        "Zn",
+                        "3d5/2"
+                    ],
+                    [
+                        "Zn",
+                        "3p"
+                    ],
+                    [
+                        "Zn",
+                        "3p1/2"
+                    ],
+                    [
+                        "Zn",
+                        "3p3/2"
+                    ],
+                    [
+                        "Zn",
+                        "3s"
+                    ],
+                    [
+                        "Zn",
+                        "LMM"
+                    ],
+                    [
+                        "Zr",
+                        "3d"
+                    ],
+                    [
+                        "Zr",
+                        "3d3/2"
+                    ],
+                    [
+                        "Zr",
+                        "3d5/2"
+                    ],
+                    [
+                        "Zr",
+                        "3p"
+                    ],
+                    [
+                        "Zr",
+                        "3p1/2"
+                    ],
+                    [
+                        "Zr",
+                        "3p3/2"
+                    ],
+                    [
+                        "Zr",
+                        "3s"
+                    ],
+                    [
+                        "Zr",
+                        "4d"
+                    ],
+                    [
+                        "Zr",
+                        "4d3/2"
+                    ],
+                    [
+                        "Zr",
+                        "4d5/2"
+                    ],
+                    [
+                        "Zr",
+                        "4p"
+                    ],
+                    [
+                        "Zr",
+                        "4p1/2"
+                    ],
+                    [
+                        "Zr",
+                        "4p3/2"
+                    ],
+                    [
+                        "Zr",
+                        "4s"
+                    ],
+                    [
+                        "Zr",
+                        "LMM"
+                    ],
+                    [
+                        "Zr",
+                        "MNN"
+                    ],
+                    [
+                        "survey",
+                        ""
+                    ],
+                    [
+                        "valence",
+                        ""
+                    ]
+                ]},
+                "maxItems": 1
+            },
+            "Excitation source": {
+                "description": "A photon source used for photoemission",
+                "type": "object",
+                "properties": {
+                    "Source to analyzer angle": {
+                        "description": "The angle between the excitation source and the analyzer's lens axis",
+                        "type": "number"
+                    },
+                    "Source": {
+                        "type": "object",
+                        "oneOf": [
+                            {"$ref": "#/definitions/Synchrotron"},
+                            {"$ref": "#/definitions/Anode"},
+                            {"$ref": "#/definitions/Gas discharge"},
+                            {"$ref": "#/definitions/Laser"}
+                        ]
+                    }
+                }
+            },
+            "Synchrotron": {
+                "type": "object",
+                "properties": {
+                    "Synchrotron name": {
+                        "description": "The name of the synchrotron",
+                        "type": "string"
+                    },
+                    "Beamline": {
+                        "type": "object",
+                        "properties": {
+                            "Name": {
+                                "description": "The name of the beamline",
+                                "type": "string"
+                            },
+                            "Energy range": {
+                                "description": "The photon energy range of the beamline, in eV",
+                                "type": "string"
+                            },
+                            "Source kind": {
+                                "type": "string",
+                                "enum": [
+                                    "Bending magnet",
+                                    "Wiggler",
+                                    "Undulator"
+                                ]
+                            },
+                            "Monochromator kind": {"type": "string"},
+                            "Polarization": {"type": "string"},
+                            "Spot size range": {
+                                "description": "The minimum and maximum spot size in micrometers",
+                                "type": "string"
+                            }
+                        }
+                    }
+                }
+            },
+            "Anode": {
+                "type": "object",
+                "properties": {
+                    "Anode material": {
+                        "description": "The material used as the anode to generate X-rays by electron bombardment",
+                        "type": "string",
+                        "enum": [
+                            "Al",
+                            "Mg",
+                            "Ag",
+                            "Cr",
+                            "Ga"
+                        ]
+                    },
+                    "Spot size": {
+                        "description": "Range of spot size diameters for the radiation at the surface of the sample, in units of micrometers",
+                        "type": "string"
+                    },
+                    "Monochromated": {"type": "boolean"},
+                    "Max voltage": {
+                        "description": "The maximum voltage allowed, in units of kV",
+                        "type": "number"
+                    },
+                    "Max power": {
+                        "description": "The maximum power allowed, in units of kW",
+                        "type": "number"
+                    }
+                }
+            },
+            "Gas discharge": {
+                "type": "object",
+                "properties": {
+                    "Gas type": {
+                        "description": "The gas used in the discharge lamp",
+                        "type": "string",
+                        "enum": [
+                            "He",
+                            "Ar"
+                        ]
+                    },
+                    "Monochromated": {"type": "boolean"}
+                }
+            },
+            "Laser": {
+                "type": "object",
+                "properties": {"Energy range": {
+                    "description": "The energy range possible, in units of eV",
+                    "type": "string"
+                }}
+            }
+        }
+    },
+    "allOf": [
+        {"$ref": "#/definitions/Instrument"},
+        {"$ref": "#/definitions/Laboratory"},
+        {"$ref": "#/definitions/Sample"},
+        {"$ref": "#/definitions/Spectrum"},
+        {"$ref": "#/definitions/Dataset"}
+    ]
 }


### PR DESCRIPTION
I noticed a few minor JSON syntax issues, such as missing commas and curly brackets, etc. I resolved these and there were no more JSON syntax error messages in my editor. However, this may have introduced unintended parent/child issues, so you should check for this based on the intent of a property.

I also added root-level properties via references to their definitions. This will now produce errors in validators that are checking for JSON-schema syntax vs JSON syntax. 
